### PR TITLE
feat: improve library usability — PublishResults, CommandHandler/QueryHandler, better errors, CLI diagnostics, performance fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,39 @@ php artisan vendor:publish --tag=mediator-config
 
 > **Tip:** If you use a custom architecture like DDD (e.g., a `src/` or `Domain/` folder instead of `app/`), you can tell the Mediator where to discover your handlers by updating the `handler_paths` array in the published `config/mediator.php`.
 
+### DDD / Bounded Contexts
+
+For DDD projects with multiple bounded contexts, configure multiple scan paths:
+
+```php
+// config/mediator.php
+'handler_paths' => [
+    base_path('src/Billing/Application'),
+    base_path('src/Users/Application'),
+    base_path('src/Inventory/Application'),
+],
+```
+
+With a folder structure like:
+
+```
+src/
+├── Billing/
+│   └── Application/
+│       ├── ProcessPayment/
+│       │   ├── ProcessPaymentCommand.php
+│       │   └── ProcessPaymentHandler.php   #[CommandHandler(ProcessPaymentCommand::class)]
+│       └── Events/
+│           └── PaymentProcessed/
+│               ├── PaymentProcessedEvent.php
+│               └── NotifyAccountingNotification.php   #[Notification(PaymentProcessedEvent::class)]
+└── Users/
+    └── Application/
+        └── RegisterUser/
+            ├── RegisterUserCommand.php
+            └── RegisterUserHandler.php   #[CommandHandler(RegisterUserCommand::class)]
+```
+
 ---
 
 ## 🧠 Core Concepts
@@ -153,6 +186,16 @@ graph LR
     B --> D[Handler 2]
     B --> E[Handler 3]
 ```
+
+### When to use Commands vs Queries vs Events
+
+| Pattern | Attribute | Direction | Mutates State? | Returns |
+|---|---|---|---|---|
+| **Command** | `#[CommandHandler]` | 1-to-1 | Yes | void or ID |
+| **Query** | `#[QueryHandler]` | 1-to-1 | No | Data / DTO |
+| **Event** | `#[Notification]` | 1-to-N | Side-effects | `PublishResults` |
+
+> `#[CommandHandler]` and `#[QueryHandler]` are semantic aliases for `#[RequestHandler]` — they behave identically but communicate intent clearly in CQRS/DDD architectures.
 
 ---
 
@@ -246,10 +289,21 @@ class LogUserRegistrationNotification
 ```
 
 ### 3. Publish and Get Results
-`publish()` returns an array of return values keyed by the handler class name.
+`publish()` returns a `PublishResults` object — a typed wrapper with a convenient API, while remaining backward-compatible with `foreach`, `count()`, and array-key access.
 
 ```php
 $results = $this->mediator->publish(new UserRegisteredEvent($userId, $email));
+
+// Typed API (new in 7.0):
+$results->get(SendWelcomeEmailNotification::class);  // result from a specific handler
+$results->handlerClasses();                           // all handler FQCNs that ran
+$results->isEmpty();                                  // true if no handlers were subscribed
+$results->count();                                    // number of handlers that ran
+
+// Backward-compatible patterns still work:
+foreach ($results as $handler => $value) { ... }
+count($results);
+$results[SendWelcomeEmailNotification::class];
 ```
 
 ---
@@ -382,6 +436,20 @@ class D {}
 ## 🔗 Pipelines (Middleware)
 
 Pipelines allow you to wrap your Handlers in logic (Transactions, Logging, Caching).
+
+### Pipeline Execution Order
+
+```
+Request/Event
+     │
+     ▼
+global_pipelines ──► request_pipelines ──► #[Pipeline] on handler ──► Handler::handle()
+                     (or notification_pipelines
+                      for publish())
+
+* #[SkipGlobalPipelines] bypasses global_pipelines and *_pipelines,
+  keeping only handler-level #[Pipeline] attributes.
+```
 
 ### 1. Global, Request & Notification Pipelines
 Configure pipelines in `config/mediator.php`. You can choose exactly when they run:

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -6,6 +6,13 @@ export default withMermaid(defineConfig({
   description: "A lightweight, zero-configuration Command/Query Bus for Laravel 11+.",
   base: '/cqbus-mediator/', // Necessary for GitHub Pages
 
+  markdown: {
+    theme: {
+      light: 'github-dark-dimmed',
+      dark: 'github-dark-dimmed',
+    }
+  },
+
   themeConfig: {
     // Logo and upper navigation
     nav: [

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -10,11 +10,12 @@ export default withMermaid(defineConfig({
     // Logo and upper navigation
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Documentation', link: '/6.1/installation', activeMatch: '^/(6.1|6.0|5.4|5.3)/' },
+      { text: 'Documentation', link: '/7.0/installation', activeMatch: '^/(7.0|6.1|6.0|5.4|5.3)/' },
       {
-        text: 'Versions', 
+        text: 'Versions',
         items: [
-          { text: 'v6.1.x (Current)', link: '/6.1/installation', activeMatch: '^/6.1/' },
+          { text: 'v7.0.x (Current)', link: '/7.0/installation', activeMatch: '^/7.0/' },
+          { text: 'v6.1.x', link: '/6.1/installation', activeMatch: '^/6.1/' },
           { text: 'v6.0.x', link: '/6.0/installation', activeMatch: '^/6.0/' },
           { text: 'v5.4.x', link: '/5.4/installation', activeMatch: '^/5.4/' },
           { text: 'v5.3.x', link: '/5.3/installation', activeMatch: '^/5.3/' },
@@ -24,6 +25,36 @@ export default withMermaid(defineConfig({
 
     // Version-specific Sidebar Configuration
     sidebar: {
+      '/7.0/': [
+        {
+          text: 'Getting Started',
+          collapsed: false,
+          items: [
+            { text: 'Installation', link: '/7.0/installation' },
+            { text: 'Core Concepts', link: '/7.0/concepts' },
+            { text: 'Upgrade to 7.0', link: '/7.0/upgrade' },
+          ]
+        },
+        {
+          text: 'Usage',
+          collapsed: false,
+          items: [
+            { text: 'Command & Queries', link: '/7.0/commands' },
+            { text: 'Event Bus', link: '/7.0/events' },
+            { text: 'Routing & Actions', link: '/7.0/actions' },
+            { text: 'Pipelines (Middleware)', link: '/7.0/pipelines' },
+            { text: 'Testing Fakes', link: '/7.0/testing' },
+          ]
+        },
+        {
+          text: 'Reference',
+          collapsed: false,
+          items: [
+            { text: 'Console Commands', link: '/7.0/console' },
+            { text: 'Production & Performance', link: '/7.0/performance' },
+          ]
+        }
+      ],
       '/6.1/': [
         {
           text: 'Getting Started',

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,24 +1,355 @@
+/* --------------------------------------------------------------------------
+   FONTS — Inter (used extensively in modern Laravel tooling)
+   -------------------------------------------------------------------------- */
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,300..700;1,14..32,300..700&display=swap');
+
+/* --------------------------------------------------------------------------
+   BRAND & GLOBAL TOKENS
+   -------------------------------------------------------------------------- */
 :root {
-  /* Laravel Red Aesthetic */
+  --vp-font-family-base: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+
+  /* Laravel Red */
   --vp-c-brand-1: #FF2D20;
   --vp-c-brand-2: #E8291D;
   --vp-c-brand-3: #D12519;
-  
-  --vp-c-brand-soft: rgba(255, 45, 32, 0.16);
+  --vp-c-brand-soft: rgba(255, 45, 32, 0.10);
 
+  /* Buttons */
   --vp-button-brand-border: transparent;
-  --vp-button-brand-text: var(--vp-c-white);
+  --vp-button-brand-text: #ffffff;
   --vp-button-brand-bg: var(--vp-c-brand-1);
   --vp-button-brand-hover-border: transparent;
-  --vp-button-brand-hover-text: var(--vp-c-white);
+  --vp-button-brand-hover-text: #ffffff;
   --vp-button-brand-hover-bg: var(--vp-c-brand-2);
   --vp-button-brand-active-border: transparent;
-  --vp-button-brand-active-text: var(--vp-c-white);
+  --vp-button-brand-active-text: #ffffff;
   --vp-button-brand-active-bg: var(--vp-c-brand-3);
+
+  /* Sidebar */
+  --vp-sidebar-width: 272px;
+
+  /* Code */
+  --vp-code-block-bg: #1e293b;
+  --vp-code-bg: rgba(100, 116, 139, 0.12);
 }
 
 .dark {
   --vp-c-brand-1: #FF4E42;
   --vp-c-brand-2: #FF2D20;
   --vp-c-brand-3: #E8291D;
+  --vp-code-block-bg: #0f172a;
+  --vp-code-bg: rgba(148, 163, 184, 0.10);
+}
+
+/* --------------------------------------------------------------------------
+   NAVBAR
+   -------------------------------------------------------------------------- */
+.VPNavBar {
+  border-bottom: 1px solid var(--vp-c-divider) !important;
+  backdrop-filter: blur(12px);
+}
+
+.VPNavBarTitle .title {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+/* --------------------------------------------------------------------------
+   SIDEBAR
+   -------------------------------------------------------------------------- */
+.VPSidebar {
+  padding-top: 1.25rem !important;
+  border-right: 1px solid var(--vp-c-divider) !important;
+}
+
+/* Section group title */
+.VPSidebarItem.level-0 > .item .text {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--vp-c-text-3);
+}
+
+/* Leaf items */
+.VPSidebarItem .text {
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+/* Active item */
+.VPSidebarItem.is-active > .item .text {
+  color: var(--vp-c-brand-1) !important;
+  font-weight: 600;
+}
+
+.VPSidebarItem.is-active > .item .indicator {
+  background-color: var(--vp-c-brand-1);
+}
+
+/* --------------------------------------------------------------------------
+   CONTENT TYPOGRAPHY
+   -------------------------------------------------------------------------- */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.vp-doc h4 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.vp-doc h1 {
+  font-size: 1.9rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  margin-bottom: 1.5rem;
+}
+
+.vp-doc h2 {
+  font-size: 1.35rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  margin-top: 2.5rem;
+}
+
+.vp-doc h3 {
+  font-size: 1.1rem;
+  margin-top: 2rem;
+}
+
+.vp-doc p {
+  line-height: 1.8;
+}
+
+/* Links */
+.vp-doc a {
+  color: var(--vp-c-brand-1);
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.vp-doc a:hover {
+  color: var(--vp-c-brand-2);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   INLINE CODE
+   -------------------------------------------------------------------------- */
+.vp-doc :not(pre) > code {
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-size: 0.84em;
+  background-color: var(--vp-code-bg);
+  color: var(--vp-c-brand-1);
+  font-weight: 500;
+  border: 1px solid rgba(255, 45, 32, 0.15);
+}
+
+.dark .vp-doc :not(pre) > code {
+  color: #fca5a5;
+  border-color: rgba(252, 165, 165, 0.15);
+}
+
+/* --------------------------------------------------------------------------
+   CODE BLOCKS
+   -------------------------------------------------------------------------- */
+div[class*='language-'] {
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+}
+
+.dark div[class*='language-'] {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+div[class*='language-'] .shiki code {
+  font-size: 0.875rem;
+  line-height: 1.75;
+}
+
+div[class*='language-'] .lang {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.5;
+}
+
+/* Code group tabs */
+.vp-code-group .tabs label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+/* --------------------------------------------------------------------------
+   TABLES
+   -------------------------------------------------------------------------- */
+.vp-doc table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  overflow: hidden;
+  display: table;
+  font-size: 0.875rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+}
+
+.vp-doc thead tr {
+  background-color: var(--vp-c-bg-soft);
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.vp-doc thead th {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--vp-c-text-2);
+  padding: 0.75rem 1rem;
+  border: none;
+}
+
+.vp-doc tbody td {
+  padding: 0.7rem 1rem;
+  border: none;
+  border-bottom: 1px solid var(--vp-c-divider);
+  vertical-align: top;
+}
+
+.vp-doc tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.vp-doc tbody tr:nth-child(even) {
+  background-color: var(--vp-c-bg-soft);
+}
+
+/* --------------------------------------------------------------------------
+   CUSTOM BLOCKS (tip / warning / info / danger)
+   -------------------------------------------------------------------------- */
+.vp-doc .custom-block {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  border-left-width: 4px;
+  padding: 1rem 1.25rem;
+}
+
+.vp-doc .custom-block.tip {
+  border-color: rgba(255, 45, 32, 0.25);
+  border-left-color: var(--vp-c-brand-1);
+  background-color: rgba(255, 45, 32, 0.04);
+}
+
+.vp-doc .custom-block.info {
+  border-color: rgba(59, 130, 246, 0.25);
+  border-left-color: #3b82f6;
+  background-color: rgba(59, 130, 246, 0.04);
+}
+
+.vp-doc .custom-block.warning {
+  border-color: rgba(245, 158, 11, 0.3);
+  border-left-color: #f59e0b;
+  background-color: rgba(245, 158, 11, 0.04);
+}
+
+.vp-doc .custom-block.danger {
+  border-color: rgba(239, 68, 68, 0.25);
+  border-left-color: #ef4444;
+  background-color: rgba(239, 68, 68, 0.04);
+}
+
+.vp-doc .custom-block-title {
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.35rem;
+}
+
+/* --------------------------------------------------------------------------
+   HOME PAGE — Hero & Features
+   -------------------------------------------------------------------------- */
+.VPHero .name .clip {
+  background: linear-gradient(135deg, #FF2D20 0%, #ff6b60 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.VPHero .tagline {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: var(--vp-c-text-2);
+}
+
+.VPFeature {
+  border-radius: 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.VPFeature:hover {
+  border-color: rgba(255, 45, 32, 0.3) !important;
+  box-shadow: 0 8px 24px rgba(255, 45, 32, 0.08);
+  transform: translateY(-2px);
+}
+
+.VPFeature .title {
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+
+/* --------------------------------------------------------------------------
+   SCROLLBAR
+   -------------------------------------------------------------------------- */
+::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--vp-c-divider);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--vp-c-text-3);
+}
+
+/* --------------------------------------------------------------------------
+   MISC REFINEMENTS
+   -------------------------------------------------------------------------- */
+
+/* Horizontal rule */
+.vp-doc hr {
+  border: none;
+  border-top: 1px solid var(--vp-c-divider);
+  margin: 2rem 0;
+}
+
+/* Blockquote */
+.vp-doc blockquote {
+  border-left: 4px solid var(--vp-c-brand-1);
+  background-color: rgba(255, 45, 32, 0.03);
+  border-radius: 0 6px 6px 0;
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+  color: var(--vp-c-text-2);
+}
+
+/* Search box */
+.VPNavBarSearch .DocSearch-Button {
+  border-radius: 8px;
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -182,10 +182,29 @@ div[class*='language-'] .lang {
 }
 
 /* Code group tabs */
+.vp-code-group .tabs {
+  background-color: #161f2e;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0 0.5rem;
+}
+
 .vp-code-group .tabs label {
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.01em;
+  color: rgba(200, 215, 235, 0.55);
+  padding: 0.6rem 0.85rem;
+  transition: color 0.15s;
+}
+
+.vp-code-group .tabs label:hover {
+  color: rgba(200, 215, 235, 0.9);
+}
+
+.vp-code-group .tabs input:checked + label {
+  color: #e2e8f0;
+  font-weight: 600;
+  border-bottom-color: var(--vp-c-brand-1);
 }
 
 /* --------------------------------------------------------------------------
@@ -305,6 +324,75 @@ div[class*='language-'] .lang {
   font-weight: 700;
   font-size: 1rem;
   letter-spacing: -0.01em;
+}
+
+/* --------------------------------------------------------------------------
+   HOME PAGE — CTA Text
+   -------------------------------------------------------------------------- */
+.home-cta-text {
+  max-width: 860px;
+  margin: 1rem auto 2rem;
+  text-align: center;
+}
+
+.home-cta-text h2 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.3;
+  margin-bottom: 0.6rem;
+}
+
+.home-cta-text p {
+  color: var(--vp-c-text-2);
+  font-size: 1rem;
+}
+
+/* --------------------------------------------------------------------------
+   HOME PAGE — Code Section
+   -------------------------------------------------------------------------- */
+.home-code-section {
+  max-width: 860px;
+  margin: 0 auto 4rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+.home-code-header {
+  background-color: #161f2e;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.home-code-header::before {
+  content: '';
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #FF2D20;
+  box-shadow: 16px 0 0 #f59e0b, 32px 0 0 #22c55e;
+  flex-shrink: 0;
+}
+
+.home-code-label {
+  margin-left: 2.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(200, 215, 235, 0.5);
+  letter-spacing: 0.03em;
+}
+
+.home-code-section div[class*='language-'] {
+  margin: 0;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
 }
 
 /* --------------------------------------------------------------------------

--- a/docs/7.0/actions.md
+++ b/docs/7.0/actions.md
@@ -1,0 +1,216 @@
+# Routing & Actions
+
+Stop digging through massive `routes/api.php` files to find where an endpoint points to. 
+
+We highly recommend using the **Action Pattern** alongside our custom attribute routing. This approach brings the route definition right next to the logic that handles it, making your codebase infinitely easier to navigate and maintain.
+
+## The "Action" Pattern (Recommended)
+
+Use the generated `Action` class as a Single Action Controller. By applying the `AsAction` trait and routing attributes (like `#[Api]`), the package automatically registers the routes and middleware into the Laravel Router.
+
+```php
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
+use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+use Ignaciocastro0713\CqbusMediator\Traits\AsAction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Router;
+
+#[Api] // ⚡ Applies 'api' middleware group AND 'api/' prefix automatically
+class RegisterUserAction
+{
+    use AsAction;
+
+    public function __construct(private readonly Mediator $mediator) {}
+
+    public static function route(Router $router): void
+    {
+        // Final route mapped: POST /api/register
+        $router->post('/register');
+    }
+
+    public function handle(RegisterUserRequest $request): JsonResponse
+    {
+        $user = $this->mediator->send($request);
+        return response()->json($user, 201);
+    }
+}
+```
+
+---
+
+## Route Model Binding
+
+The package fully supports Laravel's **Implicit Route Model Binding** directly within your Action's `handle` method.
+
+```php
+#[Api]
+class UpdateUserAction
+{
+    use AsAction;
+
+    public static function route(Router $router): void
+    {
+        // Parameter {user} matches $user in handle()
+        $router->put('/users/{user}');
+    }
+
+    public function handle(UpdateUserRequest $request, User $user): JsonResponse
+    {
+        // $user is automatically resolved from the database by Laravel
+        $updatedUser = $this->mediator->send($request);
+        return response()->json($updatedUser);
+    }
+}
+```
+
+---
+
+## Action Registration Priority
+
+Sometimes you have overlapping routes, such as `/api/users/current` and `/api/users/{user}`. Laravel's router requires the more specific route (like `/api/users/current`) to be registered first. 
+
+You can explicitly set the registration priority using the `#[Priority]` attribute on your Action class.
+
+```php
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Priority;
+
+#[Api]
+#[Priority(10)] // Higher priority registers first by default
+class GetCurrentUserAction
+{
+    use AsAction;
+
+    public static function route(Router $router): void
+    {
+        // Registers BEFORE /api/users/{user} because it has a priority of 10
+        $router->get('/current');
+    }
+
+    public function handle(GetCurrentUserRequest $request)
+    {
+        // ...
+    }
+}
+```
+
+Actions without a `#[Priority]` attribute default to `0`. You can change the global sorting direction in `config/mediator.php` using the `route_priority_direction` key (defaults to `'desc'`).
+
+### Priority Groups (Contextual Sorting)
+
+If you have a large team or multiple domains, relying on global priority integers can lead to conflicts. You can use the optional `group` argument to create isolated sorting contexts. 
+
+Groups are ordered alphabetically first, and then the actions within that group are sorted by their priority integer.
+
+```php
+// Actions without a group (globals) are always registered first.
+#[Priority(10)] 
+class A {}
+
+// Grouped actions are registered after globals, sorted alphabetically by group name ('billing' before 'users').
+#[Priority(10, group: 'billing')]
+class B {}
+
+#[Priority(20, group: 'users')] // Sorted higher within the 'users' group
+class C {}
+
+#[Priority(10, group: 'users')] 
+class D {}
+```
+
+*Note: If two actions share the exact same group and priority, the Mediator will use their fully qualified class name as a deterministic tie-breaker to ensure your routes always register in the exact same order.*
+---
+
+## Global Route Patterns
+
+If you use Laravel's global route parameter patterns (e.g. `Route::pattern('id', '[0-9]+')` in your `AppServiceProvider`), these are automatically respected by the Mediator when registering your Action routes. You don't need to do any extra configuration.
+
+---
+
+## Built-in Routing Attributes
+
+> **⚠️ Important:** Every Action class **must** have either the `#[Api]` or `#[Web]` attribute to define its base routing context. If omitted, the action will not be discovered and its routes will not be registered.
+
+- `#[Api]`: Applies the `api` middleware group and prepends `api/` to the URI.
+- `#[Web]`: Applies the `web` middleware group.
+- `#[Prefix('v1')]`: Prefixes the route URI. Can be combined with `#[Api]`.
+- `#[Name('route.name')]`: Sets the route name or appends to a prefix when a route name is defined in the `route` method.
+- `#[Middleware(['auth:sanctum'])]`: Applies custom middleware.
+- `#[Priority(10)]`: Sets the route registration priority.
+
+### Example Combining Attributes:
+
+```php
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Prefix;
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Name;
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Middleware;
+
+#[Api]
+#[Prefix('v1/orders')]
+#[Name('orders.')]
+#[Middleware(['auth:sanctum'])]
+class CreateOrderAction
+{
+    use AsAction;
+
+    public static function route(Router $router): void
+    {
+        // Final Route: POST /api/v1/orders
+        // Route Name: orders.create
+        // Middleware: api, auth:sanctum
+        $router->post('/')->name('create');
+    }
+}
+```
+
+---
+
+## 🧠 Advanced: Custom Routing Attributes
+
+CQBus Mediator is built with the Open/Closed Principle in mind. You are not limited to our built-in attributes!
+
+You can create your own routing attributes (e.g., `#[Domain]`, `#[WithoutMiddleware]`) by simply implementing the `RouteModifier` interface. The package will automatically discover and apply them.
+
+### Example: Creating a `#[Domain]` attribute
+
+**1. Create the Attribute:**
+```php
+namespace App\Attributes;
+
+use Attribute;
+use Ignaciocastro0713\CqbusMediator\Contracts\RouteModifier;
+use Ignaciocastro0713\CqbusMediator\Routing\RouteOptions;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Domain implements RouteModifier
+{
+    public function __construct(public string $domain) {}
+
+    public function modifyRoute(RouteOptions $options): void
+    {
+        // Add the domain to the Laravel RouteOptions object
+        $options->domain($this->domain);
+    }
+}
+```
+
+**2. Use it in your Action:**
+```php
+use App\Attributes\Domain;
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
+
+#[Api]
+#[Domain('api.myapp.com')] // 🪄 Your custom attribute!
+class TenantDashboardAction
+{
+    use AsAction;
+
+    public static function route(Router $router): void
+    {
+        $router->get('/dashboard');
+    }
+    
+    // ...
+}
+```

--- a/docs/7.0/commands.md
+++ b/docs/7.0/commands.md
@@ -1,0 +1,107 @@
+# Command / Query Pattern (1-to-1)
+
+Use `send()` to dispatch a Request (Command or Query) to exactly **one** Handler.
+
+## Quick Start
+
+### 1. Scaffold your Logic
+Stop writing boilerplate. Generate a Request, Handler, and Action in one command:
+
+```bash
+php artisan make:mediator-handler RegisterUserHandler --action
+```
+
+### 2. Implementation Example
+
+Below is a complete example of how to implement a user registration flow using the Mediator pattern.
+
+::: code-group
+
+```php [RegisterUserRequest.php]
+namespace App\Http\Handlers\RegisterUser;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterUserRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email',
+            'password' => 'required|min:8'
+        ];
+    }
+}
+```
+
+```php [RegisterUserHandler.php]
+namespace App\Http\Handlers\RegisterUser;
+
+use App\Models\User;
+// Use #[CommandHandler] for commands that mutate state:
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
+// Or #[QueryHandler] for read-only queries:
+// use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
+// Or the generic #[RequestHandler] if you prefer:
+// use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
+
+#[CommandHandler(RegisterUserRequest::class)]
+class RegisterUserHandler
+{
+    public function handle(RegisterUserRequest $request): User
+    {
+        // Your business logic goes here
+        return User::create($request->validated());
+    }
+}
+```
+
+```php [RegisterUserAction.php]
+namespace App\Http\Actions;
+
+use App\Http\Handlers\RegisterUser\RegisterUserRequest;
+use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
+use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+use Ignaciocastro0713\CqbusMediator\Traits\AsAction;
+use Illuminate\Routing\Router;
+
+#[Api]
+class RegisterUserAction
+{
+    use AsAction;
+
+    public function __construct(private readonly Mediator $mediator) {}
+
+    public static function route(Router $router): void
+    {
+        $router->post('/register');
+    }
+
+    public function handle(RegisterUserRequest $request)
+    {
+        // Executes the handler and returns the User
+        $user = $this->mediator->send($request);
+
+        return response()->json($user);
+    }
+}
+```
+:::
+
+## Using the Facade
+
+If you prefer not to use Dependency Injection, you can use the `Mediator` facade to dispatch requests. This can help keep your Action classes cleaner by removing the constructor:
+
+```php
+use Ignaciocastro0713\CqbusMediator\Facades\Mediator;
+
+// ...
+
+    public function handle(RegisterUserRequest $request)
+    {
+        // Dispatches via Facade
+        $user = Mediator::send($request);
+
+        return response()->json($user);
+    }
+```

--- a/docs/7.0/concepts.md
+++ b/docs/7.0/concepts.md
@@ -1,0 +1,71 @@
+# Core Concepts
+
+At the heart of this package is the `Mediator` service. Instead of components talking directly to each other, they send messages to the Mediator, which then routes them to the appropriate handlers. This results in a highly decoupled, easy-to-test architecture.
+
+We support two distinct architectural patterns out of the box:
+
+## When to Use Commands vs Queries vs Events
+
+| Pattern | Attribute | Direction | Mutates State? | Returns |
+|---|---|---|---|---|
+| **Command** | `#[CommandHandler]` | 1-to-1 | Yes | void or ID |
+| **Query** | `#[QueryHandler]` | 1-to-1 | No | Data / DTO |
+| **Event** | `#[Notification]` | 1-to-N | Side-effects | `PublishResults` |
+
+**Key rules:**
+- A Command should not return business data beyond an ID; use a follow-up Query if needed.
+- A Query must not mutate state.
+- Events describe facts that already happened — use past tense names (`UserRegisteredEvent`, not `RegisterUserEvent`).
+- Use `publish()` for side-effects that are independent of the main flow (emails, audit logs, cache invalidation).
+
+> `#[CommandHandler]` and `#[QueryHandler]` are semantic aliases for `#[RequestHandler]` — they behave identically but communicate intent clearly.
+
+---
+
+## 1. Command / Query Pattern (1-to-1)
+
+Use this pattern when you want a specific action to happen and you expect a direct result. 
+
+* **Commands:** Change the state of the system (e.g., `CreateUserRequest`, `ProcessPaymentRequest`).
+* **Queries:** Ask the system for data without changing state (e.g., `GetUserProfileRequest`).
+
+```mermaid
+graph LR
+    A[Action / Controller] -- "send($request)" --> B((Mediator))
+    B -- "runs through" --> C{Pipelines}
+    C -- "handled by" --> D[Handler]
+    D -- "returns data" --> A
+```
+
+::: info 🔄 How it flows
+1. You dispatch the request: `$mediator->send($request)`.
+2. The Mediator pushes the request through any configured **Global and Request Pipelines** (like an onion).
+3. The request hits its **dedicated Handler**, which executes your business logic.
+4. The result is returned back to the caller.
+:::
+
+---
+
+## 2. Event Bus Pattern (1-to-N)
+
+Use this pattern for side-effects. When something significant happens in your system, you "announce" it. Other parts of your system can listen and react independently.
+
+* **Events:** Represent something that already happened (e.g., `UserRegisteredEvent`, `OrderShippedEvent`).
+* **Notifications:** The classes that respond to the event (e.g., `SendWelcomeEmailNotification`).
+
+```mermaid
+graph LR
+    A[Action / Logic] -- "publish($event)" --> B((Mediator))
+    B -- "runs through" --> P{Pipelines}
+    P --> C[Notification 1]
+    P --> D[Notification 2]
+    P --> E[Notification 3]
+```
+
+::: info 📢 How it flows
+1. You broadcast the event: `$mediator->publish($event)`.
+2. The Mediator pushes the event through any configured **Global and Notification Pipelines**.
+3. The Mediator automatically discovers **all Notifications** subscribed to this event.
+4. Notifications are executed sequentially based on their **priority** level.
+5. The Mediator returns an array containing the responses of all executed notifications.
+:::

--- a/docs/7.0/concepts.md
+++ b/docs/7.0/concepts.md
@@ -67,5 +67,5 @@ graph LR
 2. The Mediator pushes the event through any configured **Global and Notification Pipelines**.
 3. The Mediator automatically discovers **all Notifications** subscribed to this event.
 4. Notifications are executed sequentially based on their **priority** level.
-5. The Mediator returns an array containing the responses of all executed notifications.
+5. The Mediator returns a `PublishResults` object containing the typed responses of all executed notifications.
 :::

--- a/docs/7.0/console.md
+++ b/docs/7.0/console.md
@@ -1,0 +1,64 @@
+# Console Commands
+
+The package provides several Artisan commands to speed up your workflow and manage the mediator.
+
+## 🛠️ Generation Commands
+
+Scaffold your classes instantly. All generation commands support a `--root` option to change the base directory (e.g., `--root=Domain/Users`).
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `make:mediator-handler` | Creates a Request and Handler class. | `--action` (adds Action), `--root=Dir` |
+| `make:mediator-action` | Creates an Action and Request class. | `--root=Dir` |
+| `make:mediator-notification`| Creates an Event and its Notification class. | `--root=Dir` |
+
+**Examples:**
+```bash
+# Uses default root folder (Handlers/)
+php artisan make:mediator-handler RegisterUserHandler --action
+
+# Changes root folder to Orders/
+php artisan make:mediator-action CreateOrderAction --root=Orders
+
+# Changes root folder to Domain/Events/
+php artisan make:mediator-notification UserRegisteredNotification --root=Domain/Events
+```
+
+## 🔍 Information Commands
+
+### `mediator:list`
+View all discovered or cached handlers, notifications, and actions in a clean console table.
+
+```bash
+php artisan mediator:list
+```
+
+**Options:**
+- `--handlers`: List only Request Handlers.
+- `--events`: List only Notifications.
+- `--actions`: List only Actions.
+
+**Output Example:**
+```text
+  Handlers
++------------------------------------------+------------------------------------------+-------------------+
+| Request                                  | Handler                                  | Pipelines         |
++------------------------------------------+------------------------------------------+-------------------+
+| App\Http\Handlers\RegisterUserRequest    | App\Http\Handlers\RegisterUserHandler    | LoggingPipeline   |
+| App\Http\Handlers\GetUserRequest         | App\Http\Handlers\GetUserHandler         | (none)            |
++------------------------------------------+------------------------------------------+-------------------+
+```
+
+The **Pipelines** column shows the effective pipeline stack (global + type-specific + handler-level) for each handler. When a cache file is loaded in a non-production environment, a warning is displayed to remind you to clear it after code changes.
+
+## 🚀 Production Optimization
+
+In development, the package scans your directories to auto-discover attributes. In production, this file-system scanning overhead should be eliminated by caching the discovery results.
+
+```bash
+# Creates the cache file
+php artisan mediator:cache 
+
+# Clears the existing cache file
+php artisan mediator:clear 
+```

--- a/docs/7.0/events.md
+++ b/docs/7.0/events.md
@@ -1,0 +1,115 @@
+# Event Bus (Publish/Subscribe)
+
+Multiple notifications can respond to the same event simultaneously. This is the **1-to-N** pattern.
+
+`publish()` returns a `PublishResults` object — a typed wrapper over the handler results:
+
+```php
+$results = $mediator->publish(new UserRegisteredEvent($userId, $email));
+
+// Typed API:
+$results->get(SendWelcomeEmailNotification::class); // result from a specific handler
+$results->handlerClasses();                          // all handler FQCNs that ran
+$results->isEmpty();                                 // true if no handlers were subscribed
+$results->count();                                   // number of handlers that ran
+
+// Backward-compatible usage still works:
+foreach ($results as $handler => $value) { ... }
+count($results);
+$results[SendWelcomeEmailNotification::class];
+```
+
+## Creating an Event and Notifications
+
+### 1. Scaffold your Event Logic
+We provide a dedicated command to scaffold an Event and its initial Notification:
+
+```bash
+php artisan make:mediator-notification UserRegisteredNotification
+```
+
+### 2. Implementation Example
+
+Below is an example of a broadcasted event with multiple listeners responding with different priorities.
+
+::: code-group
+
+```php [UserRegisteredEvent.php]
+namespace App\Http\Events\UserRegistered;
+
+class UserRegisteredEvent
+{
+    public function __construct(
+        public int $userId,
+        public string $email
+    ) {}
+}
+```
+
+```php [SendWelcomeEmailNotification.php]
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\Notification;
+use App\Http\Events\UserRegistered\UserRegisteredEvent;
+
+#[Notification(UserRegisteredEvent::class, priority: 3)]
+class SendWelcomeEmailNotification
+{
+    public function handle(UserRegisteredEvent $event): void
+    {
+        // Priority 3: Runs before LogUserRegistrationNotification
+        Mail::to($event->email)->send(new WelcomeEmail());
+    }
+}
+```
+
+```php [LogRegistrationNotification.php]
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\Notification;
+use App\Http\Events\UserRegistered\UserRegisteredEvent;
+
+#[Notification(UserRegisteredEvent::class)]
+class LogUserRegistrationNotification
+{
+    public function handle(UserRegisteredEvent $event): void
+    {
+        // Default Priority (0)
+        Log::info("User registered: {$event->userId}");
+    }
+}
+```
+
+```php [Usage.php]
+use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+
+public function __construct(private readonly Mediator $mediator) {}
+
+public function registerUser() 
+{
+    // ... logic ...
+
+    // The event is sent to all registered notifications based on their priority
+    $results = $this->mediator->publish(new UserRegisteredEvent($userId, $email));
+    
+    /* $results looks like:
+       [
+          'App\Http\Events\SendWelcomeEmailNotification' => null,
+          'App\Http\Events\LogUserRegistrationNotification' => null
+       ]
+    */
+}
+```
+:::
+
+## Using the Facade
+
+If you prefer not to use Dependency Injection via the `__construct` method, you can use the `Mediator` facade to publish events cleanly:
+
+```php
+use Ignaciocastro0713\CqbusMediator\Facades\Mediator;
+
+public function registerUser() 
+{
+    // ... logic ...
+
+    // The event is published via Facade
+    $results = Mediator::publish(new UserRegisteredEvent($userId, $email));
+}
+```

--- a/docs/7.0/events.md
+++ b/docs/7.0/events.md
@@ -78,6 +78,7 @@ class LogUserRegistrationNotification
 
 ```php [Usage.php]
 use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
 
 public function __construct(private readonly Mediator $mediator) {}
 
@@ -85,15 +86,19 @@ public function registerUser()
 {
     // ... logic ...
 
-    // The event is sent to all registered notifications based on their priority
+    /** @var PublishResults $results */
     $results = $this->mediator->publish(new UserRegisteredEvent($userId, $email));
-    
-    /* $results looks like:
-       [
-          'App\Http\Events\SendWelcomeEmailNotification' => null,
-          'App\Http\Events\LogUserRegistrationNotification' => null
-       ]
-    */
+
+    // Typed API — access results by handler class:
+    $emailResult = $results->get(SendWelcomeEmailNotification::class);
+
+    // Inspect what ran:
+    $results->handlerClasses(); // ['SendWelcomeEmailNotification', 'LogUserRegistrationNotification']
+    $results->isEmpty();        // false — two handlers ran
+    $results->count();          // 2
+
+    // Legacy array access still works:
+    foreach ($results as $handler => $value) { ... }
 }
 ```
 :::

--- a/docs/7.0/installation.md
+++ b/docs/7.0/installation.md
@@ -8,7 +8,7 @@ If you are tired of massive, unmaintainable controllers and tangled business log
 
 Before you start, ensure your environment meets the following:
 - **PHP:** 8.2 or higher
-- **Laravel:** 11.0 or higher
+- **Laravel:** 11.0, 12.0, or 13.0
 
 ## Installing via Composer
 
@@ -29,3 +29,13 @@ php artisan vendor:publish --tag=mediator-config
 ::: tip 🏗️ Using Domain-Driven Design (DDD)?
 By default, the package scans your `app/` directory for Handlers and Actions. If you use a custom architecture (e.g., a `src/Domain/` folder), simply update the `handler_paths` array in the published `config/mediator.php` file to point to your custom directories.
 :::
+
+## What's New in v7.0
+
+- **Semantic CQRS attributes** — `#[CommandHandler]` and `#[QueryHandler]` as expressive aliases for `#[RequestHandler]`.
+- **`PublishResults` typed API** — `publish()` now returns a typed object instead of a plain array, with methods like `get()`, `handlerClasses()`, and `isEmpty()`.
+- **Better error messages** — `InvalidRequestClassException` now names the offending attribute; new `InvalidPipelineException` validates pipelines at boot time.
+- **Pipeline cache fix** — Zero-reflection dispatch in production is now guaranteed. Regenerate your cache after upgrading.
+- **`mediator:list` improvements** — Shows the effective pipeline stack per handler in a new Pipelines column.
+
+See the [Upgrade Guide](/7.0/upgrade) for migration steps.

--- a/docs/7.0/installation.md
+++ b/docs/7.0/installation.md
@@ -1,0 +1,31 @@
+# Installation
+
+Welcome to **CQBus Mediator**! 🚀 
+
+If you are tired of massive, unmaintainable controllers and tangled business logic in your Laravel applications, you are in the right place. This package brings the power of the **CQRS (Command/Query Responsibility Segregation)** pattern to your app with zero friction, utilizing modern PHP 8 Attributes.
+
+## Requirements
+
+Before you start, ensure your environment meets the following:
+- **PHP:** 8.2 or higher
+- **Laravel:** 11.0 or higher
+
+## Installing via Composer
+
+Pull the package into your project using Composer. Laravel's package discovery will handle the rest automatically.
+
+```bash
+composer require ignaciocastro0713/cqbus-mediator
+```
+
+## Configuration (Optional)
+
+Out of the box, CQBus Mediator is ready to go. However, if you want to tweak its behavior—like defining custom directories for your handlers or registering global pipelines—you should publish the configuration file:
+
+```bash
+php artisan vendor:publish --tag=mediator-config
+```
+
+::: tip 🏗️ Using Domain-Driven Design (DDD)?
+By default, the package scans your `app/` directory for Handlers and Actions. If you use a custom architecture (e.g., a `src/Domain/` folder), simply update the `handler_paths` array in the published `config/mediator.php` file to point to your custom directories.
+:::

--- a/docs/7.0/performance.md
+++ b/docs/7.0/performance.md
@@ -1,0 +1,47 @@
+# Production & Performance
+
+CQBus Mediator is designed with performance in mind. Because it relies on PHP Attributes for discovery, it must scan your application's directories to find `#[RequestHandler]`, `#[Notification]`, and routing attributes.
+
+While this auto-discovery is incredibly convenient for development (zero configuration), scanning the file system and reading attributes via Reflection on every request in a production environment is inefficient.
+
+## Zero-Reflection Caching
+
+To eliminate discovery and Reflection overhead, you **must** cache the mediator registry during your production deployment process.
+
+```bash
+php artisan mediator:cache
+```
+
+When you run this command, the package performs all the heavy lifting:
+1. It scans your codebase for Handlers, Notifications, and Actions.
+2. It resolves all `#[Pipeline]` and `#[SkipGlobalPipelines]` attributes.
+3. It resolves all Route-related attributes (like `#[Api]`, `#[Web]`, `#[Middleware]`, etc.) directly into route definitions to completely bypass Reflection when loading routes.
+4. It compiles everything into a single, flat, heavily optimized PHP array.
+Once cached, the package will read directly from the generated file (`bootstrap/cache/mediator.php`). **No Reflection API is used at runtime when the cache exists**, dropping the overhead to micro-seconds.
+
+### Benchmarks
+
+| Benchmark | Source / Dev Mode | Cached (Production) | Improvement |
+|:----------|:-----------:|:-------:|:-------:|
+| **Discovery (Boot Phase)** | ~157.00 ms | **~0.06 ms** | ~2,500x Faster |
+| **Reflection / Attribute Reading** | ~16.00 μs | **~4.00 μs** | ~4x Faster |
+| **Simple Dispatch (`send`)** | - | **~68.00 μs** | Near Zero Overhead |
+
+As you can see, caching reduces the boot discovery time from milliseconds to fractions of a millisecond, and eliminates the Reflection penalty entirely during the dispatch cycle.
+
+## Pipeline Cache (Fixed in 7.0)
+
+Prior to v7.0, a bug caused the pipeline pre-computation in `mediator:cache` to use incorrect internal cache keys, resulting in `ReflectionClass` calls on every handler dispatch even in production. This is now fixed — with a valid cache file, handlers dispatch with **zero Reflection calls**.
+
+After upgrading to 7.0, run `php artisan mediator:clear && php artisan mediator:cache` to benefit from this fix.
+
+## Deployment Script Example
+
+If you use a deployment script (like Laravel Envoyer, GitHub Actions, or a bash script), ensure you add the `mediator:cache` command alongside your standard Laravel optimization commands:
+
+```bash
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+php artisan mediator:cache # <--- Add this!
+```

--- a/docs/7.0/pipelines.md
+++ b/docs/7.0/pipelines.md
@@ -2,17 +2,26 @@
 
 ## Execution Order
 
-```
-Request/Event
-     │
-     ▼
-global_pipelines ──► request_pipelines ──► #[Pipeline] on handler ──► Handler::handle()
-                     (or notification_pipelines
-                      for publish())
+```mermaid
+flowchart LR
+    S1(["send()"]) --> G[global_pipelines]
+    S2(["publish()"]) --> G
+    G --> R[request_pipelines]
+    G --> N[notification_pipelines]
+    R --> P["#[Pipeline] on handler"]
+    N --> P
+    P --> H(["Handler::handle()"])
 
-* #[SkipGlobalPipelines] bypasses global_pipelines and *_pipelines,
-  keeping only handler-level #[Pipeline] attributes.
+    style S1 fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style S2 fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style H  fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style G  fill:#FF2D20,stroke:#FF2D20,color:#fff
+    style R  fill:#e8291d,stroke:#e8291d,color:#fff
+    style N  fill:#e8291d,stroke:#e8291d,color:#fff
+    style P  fill:#b91c1c,stroke:#b91c1c,color:#fff
 ```
+
+> `#[SkipGlobalPipelines]` bypasses `global_pipelines` and `*_pipelines`, keeping only handler-level `#[Pipeline]` attributes.
 
 Pipelines allow you to wrap your Handlers in reusable logic. Think of them exactly like **Laravel Middleware**, but instead of operating at the HTTP layer, they operate directly at the Mediator layer. 
 

--- a/docs/7.0/pipelines.md
+++ b/docs/7.0/pipelines.md
@@ -62,7 +62,7 @@ class LoggingPipeline
 
 ---
 
-## 2. Segregated Pipelines (New in 6.1)
+## 2. Segregated Pipelines
 
 Sometimes you want pipelines that apply *only* to Requests, or *only* to Notifications. You can configure this easily in your `config/mediator.php`.
 

--- a/docs/7.0/pipelines.md
+++ b/docs/7.0/pipelines.md
@@ -1,0 +1,132 @@
+# Pipelines (Middleware)
+
+## Execution Order
+
+```
+Request/Event
+     │
+     ▼
+global_pipelines ──► request_pipelines ──► #[Pipeline] on handler ──► Handler::handle()
+                     (or notification_pipelines
+                      for publish())
+
+* #[SkipGlobalPipelines] bypasses global_pipelines and *_pipelines,
+  keeping only handler-level #[Pipeline] attributes.
+```
+
+Pipelines allow you to wrap your Handlers in reusable logic. Think of them exactly like **Laravel Middleware**, but instead of operating at the HTTP layer, they operate directly at the Mediator layer. 
+
+::: tip 💡 Why is this powerful?
+Because pipelines run at the Mediator level, your logic (like Database Transactions or Auditing) will execute perfectly whether the handler was triggered by an HTTP Request, an Artisan Console Command, or a Queued Job!
+:::
+
+---
+
+## 1. Global Pipelines
+
+Global pipelines run before *every* handler dispatched via the `send()` or `publish()` method. This is the perfect place for global logging or APM (Application Performance Monitoring) tracking.
+
+Register them in your `config/mediator.php` file:
+
+```php
+// config/mediator.php
+return [
+    'global_pipelines' => [
+        \App\Pipelines\LoggingPipeline::class,
+    ],
+];
+```
+
+A pipeline is simply an invokable class that receives the payload and a `$next` Closure:
+
+```php
+namespace App\Pipelines;
+
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+class LoggingPipeline
+{
+    public function handle(mixed $payload, Closure $next): mixed
+    {
+        Log::info('Started executing: ' . get_class($payload));
+        
+        $response = $next($payload); // Move deeper into the onion
+        
+        Log::info('Finished executing successfully.');
+        
+        return $response;
+    }
+}
+```
+
+---
+
+## 2. Segregated Pipelines (New in 6.1)
+
+Sometimes you want pipelines that apply *only* to Requests, or *only* to Notifications. You can configure this easily in your `config/mediator.php`.
+
+```php
+// config/mediator.php
+return [
+    'global_pipelines' => [
+        \App\Pipelines\LoggingPipeline::class, // Runs for EVERYTHING
+    ],
+    
+    'request_pipelines' => [
+        \App\Pipelines\DatabaseTransactionPipeline::class, // Runs ONLY for send()
+    ],
+    
+    'notification_pipelines' => [
+        \App\Pipelines\MetricsPipeline::class, // Runs ONLY for publish()
+    ],
+];
+```
+
+These type-specific pipelines run **after** the `global_pipelines` but **before** the handler-level pipelines.
+
+---
+
+## 3. Handler-Level Pipelines
+
+Sometimes you only need a pipeline for specific actions. You can apply them directly to your handlers using the `#[Pipeline]` attribute. 
+
+*Note: Handler-level pipelines run **after** Global and Type-specific pipelines.*
+
+```php
+use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\Pipeline;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
+
+#[RequestHandler(CreateOrderRequest::class)]
+#[Pipeline(DatabaseTransactionPipeline::class)] // 🛡️ Ensures DB consistency
+class CreateOrderHandler
+{
+    public function handle(CreateOrderRequest $request): Order
+    {
+        return Order::create($request->validated());
+    }
+}
+```
+
+---
+
+## 4. Skipping Global Pipelines
+
+What if you have a simple health-check query, and you don't want it to trigger your heavy Global Logging pipeline? Use the `#[SkipGlobalPipelines]` attribute.
+
+*Note: When you use `#[SkipGlobalPipelines]`, it bypasses `global_pipelines`, `request_pipelines`, and `notification_pipelines`. Only handler-level `#[Pipeline]` attributes will run.*
+
+```php
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
+use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\SkipGlobalPipelines;
+
+#[RequestHandler(HealthCheckRequest::class)]
+#[SkipGlobalPipelines] // 🛑 Global and Type-Specific pipelines will be ignored
+class HealthCheckHandler
+{
+    public function handle(HealthCheckRequest $request): string
+    {
+        return 'All systems operational.'; 
+    }
+}
+```

--- a/docs/7.0/testing.md
+++ b/docs/7.0/testing.md
@@ -1,0 +1,86 @@
+# Testing Fakes
+
+Testing applications built with the Mediator pattern should be simple. You shouldn't need to execute complex business logic, database queries, or external API calls just to verify that a controller or action dispatched the correct command.
+
+To solve this, CQBus Mediator provides a powerful `Mediator` Facade with a built-in fake.
+
+## Faking the Mediator
+
+You can instruct the Mediator to swap itself with a test double by calling the `Mediator::fake()` method. Once faked, the Mediator will **intercept and record** all requests and events instead of executing their handlers.
+
+You can then use expressive assertions to verify your application's behavior.
+
+```php
+use Ignaciocastro0713\CqbusMediator\Facades\Mediator;
+use App\Http\Handlers\RegisterUser\RegisterUserRequest;
+use App\Http\Events\UserRegistered\UserRegisteredEvent;
+
+it('dispatches the correct request and events', function () {
+    // 1. Swap the real mediator with the fake
+    Mediator::fake();
+
+    // 2. Perform your application action (e.g., an HTTP request)
+    $response = $this->postJson('/api/register', [
+        'email' => 'test@example.com',
+        'password' => 'secret123'
+    ]);
+
+    $response->assertStatus(201);
+
+    // 3. Assert a specific Request was sent
+    Mediator::assertSent(RegisterUserRequest::class);
+    
+    // 4. Assert a specific Event was published
+    Mediator::assertPublished(UserRegisteredEvent::class);
+});
+```
+
+## Advanced Assertions (Closures)
+
+Sometimes you need to verify not just *that* a request was sent, but that it contained the correct data. All assertion methods accept a closure (truth test) that receives the intercepted object.
+
+```php
+it('sends the request with the correct formatted email', function () {
+    Mediator::fake();
+
+    $this->postJson('/api/register', [
+        'email' => '  TEST@EXAMPLE.com  ', // Messy input
+    ]);
+
+    // Verify the request was sent and the data was properly formatted
+    Mediator::assertSent(function (RegisterUserRequest $request) {
+        return $request->email === 'test@example.com'; 
+    });
+});
+```
+
+## Available Assertions
+
+Here is the full list of assertions available on the faked Mediator:
+
+| Method | Description |
+|--------|-------------|
+| `Mediator::assertSent($request)` | Asserts a specific request class or closure truth test was sent. |
+| `Mediator::assertNotSent($request)` | Asserts a specific request was **not** sent. |
+| `Mediator::assertPublished($event)` | Asserts a specific event class or closure truth test was published. |
+| `Mediator::assertNotPublished($event)` | Asserts a specific event was **not** published. |
+| `Mediator::assertNothingSent()` | Asserts that absolutely zero requests were sent. |
+| `Mediator::assertNothingPublished()` | Asserts that absolutely zero events were published. |
+
+## Inspecting the Records
+
+If you need to perform complex assertions or inspect multiple dispatched items, you can retrieve the underlying Collections using the `sent()` and `published()` methods:
+
+```php
+it('dispatches multiple notifications', function () {
+    Mediator::fake();
+
+    // ... run code that publishes multiple events ...
+
+    // Get a collection of all UserRegisteredEvent instances that were published
+    $events = Mediator::published(UserRegisteredEvent::class);
+
+    expect($events)->toHaveCount(3);
+    expect($events->first()->userId)->toBe(1);
+});
+```

--- a/docs/7.0/testing.md
+++ b/docs/7.0/testing.md
@@ -4,6 +4,24 @@ Testing applications built with the Mediator pattern should be simple. You shoul
 
 To solve this, CQBus Mediator provides a powerful `Mediator` Facade with a built-in fake.
 
+## Testing with `PublishResults`
+
+When testing real dispatches (without faking), `publish()` returns a `PublishResults` object. Use its typed API in assertions:
+
+```php
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
+
+it('publishes an event and returns typed results', function () {
+    $results = $this->mediator->publish(new OrderShippedEvent($orderId));
+
+    expect($results)->toBeInstanceOf(PublishResults::class)
+        ->and($results->isEmpty())->toBeFalse()
+        ->and($results->get(NotifyCustomerHandler::class))->toBe('email_sent');
+});
+```
+
+> **Note:** `Mediator::fake()` returns `new PublishResults()` (empty) — the fake records the event but does not execute handlers.
+
 ## Faking the Mediator
 
 You can instruct the Mediator to swap itself with a test double by calling the `Mediator::fake()` method. Once faked, the Mediator will **intercept and record** all requests and events instead of executing their handlers.

--- a/docs/7.0/upgrade.md
+++ b/docs/7.0/upgrade.md
@@ -1,0 +1,110 @@
+# Upgrading To 7.0
+
+CQBus Mediator v7.0 is a major release that improves API expressiveness, adds semantic CQRS attributes, improves error messages, and fixes a production cache bug.
+
+## Breaking Changes
+
+### 1. `publish()` returns `PublishResults` instead of `array`
+
+The `Mediator::publish()` method (and `MediatorFake::publish()`) now returns a `PublishResults` object instead of a plain PHP array.
+
+**Most existing code will continue to work unchanged** because `PublishResults` implements `ArrayAccess`, `Countable`, and `IteratorAggregate`:
+
+```php
+// These patterns continue to work:
+foreach ($results as $handler => $value) { ... }  // ✅ IteratorAggregate
+count($results);                                   // ✅ Countable
+$results[MyHandler::class];                        // ✅ ArrayAccess
+```
+
+**Update these patterns** if they exist in your code:
+
+```php
+// ❌ Breaks:
+is_array($results);          // → use $results instanceof PublishResults
+array_keys($results);        // → use $results->handlerClasses()
+array $r = $mediator->publish(...);  // → remove array type-hint
+
+// ✅ New API:
+$results->get(MyHandler::class);   // typed result retrieval
+$results->all();                   // raw array
+$results->isEmpty();               // check if no handlers ran
+$results->handlerClasses();        // list of handler FQCNs
+```
+
+### 2. Pipeline cache file format changed
+
+The `bootstrap/cache/mediator.php` format for pipeline keys has changed. After upgrading, regenerate the cache:
+
+```bash
+php artisan mediator:clear
+php artisan mediator:cache
+```
+
+## New Features
+
+### 1. Semantic CQRS attributes: `#[CommandHandler]` and `#[QueryHandler]`
+
+Two new attributes alias `#[RequestHandler]` with semantic meaning:
+
+```php
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
+
+// Command: mutates state, returns void or an ID
+#[CommandHandler(CreateOrderCommand::class)]
+class CreateOrderHandler
+{
+    public function handle(CreateOrderCommand $cmd): string { ... }
+}
+
+// Query: only reads state, returns data
+#[QueryHandler(GetOrderQuery::class)]
+class GetOrderHandler
+{
+    public function handle(GetOrderQuery $q): Order { ... }
+}
+```
+
+### 2. `PublishResults` typed API
+
+```php
+$results = $mediator->publish(new OrderShippedEvent($orderId));
+
+// New typed methods:
+$results->get(NotifyCustomerHandler::class);  // specific handler result
+$results->handlerClasses();                   // all handler FQCNs
+$results->isEmpty();                          // true if no handlers ran
+```
+
+### 3. `mediator:list` now shows the Pipelines column
+
+```
++----------------------------+-------------------------+-------------------+
+| Request                    | Handler                 | Pipelines         |
++----------------------------+-------------------------+-------------------+
+| CreateOrderCommand         | CreateOrderHandler      | LoggingPipeline   |
+| GetOrderQuery              | GetOrderHandler         | (none)            |
++----------------------------+-------------------------+-------------------+
+```
+
+### 4. Better error messages
+
+- `InvalidRequestClassException` now tells you which attribute (`#[CommandHandler]`, `#[QueryHandler]`, `#[RequestHandler]`, or `#[Notification]`) references a non-existent class.
+- `InvalidPipelineException` (new) is thrown at boot time when a pipeline class in `config/mediator.php` does not exist, with actionable suggestions.
+
+### 5. Performance: pipeline cache bug fix
+
+In versions before 7.0, the pipeline pre-computation in `mediator:cache` used incorrect cache keys, causing `ReflectionClass` calls on every dispatch even in production. This is now fixed. After upgrading and regenerating the cache, handlers will benefit from zero-reflection dispatch in production.
+
+## Upgrade Steps
+
+1. Run `composer require ignaciocastro0713/cqbus-mediator:^7.0`
+2. Search your codebase for `is_array($result)` or `array_keys($result)` where `$result` comes from `publish()` and update them (see Breaking Changes above).
+3. Remove any strict `array` type-hints on variables receiving `publish()` results.
+4. Regenerate the mediator cache:
+   ```bash
+   php artisan mediator:clear
+   php artisan mediator:cache
+   ```
+5. Optionally replace `#[RequestHandler]` with `#[CommandHandler]` or `#[QueryHandler]` for semantic clarity (no functional change required).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,42 +1,59 @@
 ---
-# Esta es tu Landing Page. Se renderiza con un diseño espectacular por defecto en VitePress.
 layout: home
 
 hero:
   name: "CQBus Mediator"
-  text: "for Laravel"
-  tagline: "A modern CQRS Mediator using PHP 8 Attributes, auto-discovery, and routing pipelines."
+  text: "Clean architecture for Laravel"
+  tagline: "Decouple your commands, queries, and events with zero configuration. Auto-discovery, attribute routing, and pipelines — out of the box."
   actions:
     - theme: brand
-      text: Get Started
+      text: Get Started →
       link: /7.0/installation
     - theme: alt
       text: View on GitHub
       link: https://github.com/IgnacioCastro0713/cqbus-mediator
 
 features:
-  - title: ⚡ Zero Config
-    details: Automatically discovers Handlers and Events using modern PHP Attributes (`#[RequestHandler]`, `#[EventHandler]`). No arrays to map.
-  - title: 📢 Dual Pattern Support
-    details: Seamlessly handle both Command/Query (one-to-one) and Event Bus (one-to-many) patterns in the same package.
-  - title: 🎮 Attribute Routing
-    details: Manage routes, prefixes, and middleware directly in your Action classes—say goodbye to bloated route files.
+  - icon: 🚀
+    title: Zero Configuration
+    details: Drop in the package and go. Handlers, notifications, and actions are discovered automatically — no registration arrays, no service providers to edit.
+
+  - icon: ⚡
+    title: CQRS & Event Bus
+    details: First-class support for Commands, Queries, and Events in one package. Use <code>#[CommandHandler]</code>, <code>#[QueryHandler]</code>, and <code>#[Notification]</code> to communicate intent clearly.
+
+  - icon: 🛣️
+    title: Attribute Routing
+    details: Define your route right next to your handler. <code>#[Api]</code>, <code>#[Prefix]</code>, <code>#[Middleware]</code> — no more hunting through bloated route files.
+
+  - icon: 🔗
+    title: Layered Pipelines
+    details: Wrap every dispatch in reusable middleware — globally, per type, or per handler. Works seamlessly whether triggered by HTTP, CLI, or a queued job.
+
+  - icon: 🧪
+    title: Built for Testing
+    details: <code>Mediator::fake()</code> intercepts and records all dispatches so you can assert commands and events without running a single handler.
+
+  - icon: ⚙️
+    title: Production Ready
+    details: Cache the entire mediator registry with <code>php artisan mediator:cache</code> for zero-reflection dispatch in production — from 157ms boot to 0.06ms.
 ---
 
-<br>
-
-<div style="max-width: 800px; margin: 0 auto; text-align: center;">
-  <h2>Stop writing Fat Controllers. Start writing Actions.</h2>
-  <p style="color: var(--vp-c-text-2); margin-bottom: 2rem;">Decouple your business logic, routing, and side effects instantly.</p>
+<div class="home-cta-text">
+  <h2>Stop writing Fat Controllers.<br>Start writing Actions.</h2>
+  <p>Decouple your business logic, routing, and side effects instantly.</p>
 </div>
+
+<div class="home-code-section">
+  <div class="home-code-header">
+    <span class="home-code-label">The full CQRS flow — in one Action class</span>
+  </div>
 
 ```php
 // app/Http/Actions/RegisterUserAction.php
-use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
-use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\Pipeline;
-use Ignaciocastro0713\CqbusMediator\Traits\AsAction;
 
 #[Api]
+#[CommandHandler(RegisterUserRequest::class)]
 #[Pipeline(DatabaseTransactionPipeline::class)]
 class RegisterUserAction
 {
@@ -46,15 +63,17 @@ class RegisterUserAction
 
     public static function route(Router $router): void
     {
-        $router->post('/register');
+        $router->post('/register');                    // POST /api/register
     }
 
     public function handle(RegisterUserRequest $request): JsonResponse
     {
-        $user = $this->mediator->send($request); 
-        $this->mediator->publish(new UserRegisteredEvent($user)); 
-        
+        $user = $this->mediator->send($request);                       // → RegisterUserHandler
+        $this->mediator->publish(new UserRegisteredEvent($user->id));  // → N notifications
+
         return response()->json($user, 201);
     }
 }
 ```
+
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hero:
   actions:
     - theme: brand
       text: Get Started
-      link: /6.1/installation
+      link: /7.0/installation
     - theme: alt
       text: View on GitHub
       link: https://github.com/IgnacioCastro0713/cqbus-mediator

--- a/src/Attributes/Handlers/CommandHandler.php
+++ b/src/Attributes/Handlers/CommandHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ignaciocastro0713\CqbusMediator\Attributes\Handlers;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+readonly class CommandHandler extends RequestHandler
+{
+    // Semantic alias for RequestHandler — use for commands that mutate state.
+}

--- a/src/Attributes/Handlers/QueryHandler.php
+++ b/src/Attributes/Handlers/QueryHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ignaciocastro0713\CqbusMediator\Attributes\Handlers;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+readonly class QueryHandler extends RequestHandler
+{
+    // Semantic alias for RequestHandler — use for queries that only read state.
+}

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -6,6 +6,7 @@ namespace Ignaciocastro0713\CqbusMediator\Console;
 
 use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\Pipeline;
 use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\SkipGlobalPipelines;
+use Ignaciocastro0713\CqbusMediator\Constants\MediatorConstants;
 use Ignaciocastro0713\CqbusMediator\Discovery\MediatorDiscovery;
 use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidRequestClassException;
 use Ignaciocastro0713\CqbusMediator\MediatorConfig;
@@ -43,6 +44,8 @@ class CacheCommand extends Command
         }
 
         $globalPipelines = MediatorConfig::pipelines();
+        $requestPipelines = MediatorConfig::requestPipelines();
+        $notificationPipelines = MediatorConfig::notificationPipelines();
         $pipelinesCache = [];
 
         $notificationClasses = [];
@@ -62,9 +65,17 @@ class CacheCommand extends Command
 
             $shouldSkipGlobal = ! empty($reflection->getAttributes(SkipGlobalPipelines::class));
 
-            $pipelinesCache[$handlerClass] = $shouldSkipGlobal
+            $isNotification = in_array($handlerClass, $notificationClasses, true);
+            $type = $isNotification
+                ? MediatorConstants::PIPELINE_TYPE_NOTIFICATION
+                : MediatorConstants::PIPELINE_TYPE_REQUEST;
+
+            $typePipelines = $isNotification ? $notificationPipelines : $requestPipelines;
+            $allGlobal = array_merge($globalPipelines, $typePipelines);
+
+            $pipelinesCache[$handlerClass . ':' . $type] = $shouldSkipGlobal
                 ? $handlerPipelines
-                : array_merge($globalPipelines, $handlerPipelines);
+                : array_merge($allGlobal, $handlerPipelines);
         }
 
         $content = "<?php\n\nreturn " . var_export([

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Ignaciocastro0713\CqbusMediator\Console;
 
+use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\Pipeline;
+use Ignaciocastro0713\CqbusMediator\Attributes\Pipelines\SkipGlobalPipelines;
+use Ignaciocastro0713\CqbusMediator\Constants\MediatorConstants;
 use Ignaciocastro0713\CqbusMediator\Discovery\MediatorDiscovery;
 use Ignaciocastro0713\CqbusMediator\MediatorConfig;
 use Illuminate\Console\Command;
+use ReflectionClass;
+use ReflectionException;
 use Symfony\Component\Console\Command\Command as ConsoleCommand;
 
 class ListCommand extends Command
@@ -34,6 +39,13 @@ class ListCommand extends Command
             $actions = $cached['actions'] ?? [];
             $notifications = $cached['notifications'] ?? [];
             $this->info('📦 Loading from cache: bootstrap/cache/mediator.php');
+
+            if (app()->environment() !== 'production') {
+                $this->warn(
+                    'Cache is active in a non-production environment ("' . app()->environment() . '"). ' .
+                    'Run `php artisan mediator:clear` to pick up handler changes.'
+                );
+            }
         } else {
             $handlerPaths = MediatorConfig::handlerPaths();
             $discovered = MediatorDiscovery::discover($handlerPaths);
@@ -79,10 +91,12 @@ class ListCommand extends Command
 
         $rows = [];
         foreach ($handlers as $request => $handler) {
-            $rows[] = [$request, $handler];
+            /** @var class-string $handler */
+            $pipelines = $this->resolvePipelinesForHandler($handler, MediatorConstants::PIPELINE_TYPE_REQUEST);
+            $rows[] = [$request, $handler, $this->formatPipelines($pipelines)];
         }
 
-        $this->table(['Request', 'Handler'], $rows);
+        $this->table(['Request', 'Handler', 'Pipelines'], $rows);
         $this->newLine();
     }
 
@@ -103,16 +117,65 @@ class ListCommand extends Command
         $rows = [];
         foreach ($notifications as $event => $handlers) {
             foreach ($handlers as $handlerInfo) {
+                /** @var class-string $handlerClass */
+                $handlerClass = $handlerInfo['handler'];
+                $pipelines = $this->resolvePipelinesForHandler($handlerClass, MediatorConstants::PIPELINE_TYPE_NOTIFICATION);
                 $rows[] = [
                     $event,
-                    $handlerInfo['handler'],
+                    $handlerClass,
                     $handlerInfo['priority'],
+                    $this->formatPipelines($pipelines),
                 ];
             }
         }
 
-        $this->table(['Event', 'Handler', 'Priority'], $rows);
+        $this->table(['Event', 'Handler', 'Priority', 'Pipelines'], $rows);
         $this->newLine();
+    }
+
+    /**
+     * Resolves the effective pipeline stack for a handler (global + type + handler-level).
+     *
+     * @param class-string $handlerClass
+     * @return array<class-string>
+     */
+    private function resolvePipelinesForHandler(string $handlerClass, string $type): array
+    {
+        $globalPipelines = MediatorConfig::pipelines();
+        $typePipelines = $type === MediatorConstants::PIPELINE_TYPE_REQUEST
+            ? MediatorConfig::requestPipelines()
+            : MediatorConfig::notificationPipelines();
+
+        try {
+            $reflection = new ReflectionClass($handlerClass);
+
+            $pipelineAttributes = $reflection->getAttributes(Pipeline::class);
+            $handlerPipelines = empty($pipelineAttributes) ? [] : $pipelineAttributes[0]->newInstance()->pipes;
+
+            $shouldSkipGlobal = ! empty($reflection->getAttributes(SkipGlobalPipelines::class));
+            $allGlobal = array_merge($globalPipelines, $typePipelines);
+
+            return $shouldSkipGlobal
+                ? $handlerPipelines
+                : array_merge($allGlobal, $handlerPipelines);
+        } catch (ReflectionException) {
+            return array_merge($globalPipelines, $typePipelines);
+        }
+    }
+
+    /**
+     * @param array<class-string> $pipelines
+     */
+    private function formatPipelines(array $pipelines): string
+    {
+        if (empty($pipelines)) {
+            return '(none)';
+        }
+
+        return implode(', ', array_map(
+            fn (string $fqcn): string => class_basename($fqcn),
+            $pipelines
+        ));
     }
 
     /**

--- a/src/Constants/MediatorConstants.php
+++ b/src/Constants/MediatorConstants.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Ignaciocastro0713\CqbusMediator\Constants;
 
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
 use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\Notification;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
 use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
 use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Api;
 use Ignaciocastro0713\CqbusMediator\Attributes\Routing\Web;
@@ -24,7 +26,16 @@ final class MediatorConstants
     public const ATTRIBUTE_API_ROUTE = Api::class;
     public const ATTRIBUTE_WEB_ROUTE = Web::class;
     public const ATTRIBUTE_REQUEST_HANDLER = RequestHandler::class;
+    public const ATTRIBUTE_COMMAND_HANDLER = CommandHandler::class;
+    public const ATTRIBUTE_QUERY_HANDLER = QueryHandler::class;
     public const ATTRIBUTE_NOTIFICATION = Notification::class;
+
+    /** @var array<string> All request-handler attribute class names (including aliases). */
+    public const REQUEST_HANDLER_ATTRIBUTES = [
+        self::ATTRIBUTE_REQUEST_HANDLER,
+        self::ATTRIBUTE_COMMAND_HANDLER,
+        self::ATTRIBUTE_QUERY_HANDLER,
+    ];
 
     // Pipeline Types
     public const PIPELINE_TYPE_REQUEST = 'request';

--- a/src/Contracts/Mediator.php
+++ b/src/Contracts/Mediator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ignaciocastro0713\CqbusMediator\Contracts;
 
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
+
 interface Mediator
 {
     /**
@@ -19,7 +21,7 @@ interface Mediator
      * Unlike send(), multiple handlers can respond to the same event.
      *
      * @param object $event The event object to publish
-     * @return array<mixed> Results from all handlers, keyed by handler class name
+     * @return PublishResults Results from all handlers, keyed by handler class name
      */
-    public function publish(object $event): array;
+    public function publish(object $event): PublishResults;
 }

--- a/src/Discovery/MediatorDiscovery.php
+++ b/src/Discovery/MediatorDiscovery.php
@@ -6,6 +6,8 @@ namespace Ignaciocastro0713\CqbusMediator\Discovery;
 
 use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\Notification;
 use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
 use Ignaciocastro0713\CqbusMediator\Constants\MediatorConstants;
 use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidRequestClassException;
 use InvalidArgumentException;
@@ -58,7 +60,7 @@ final class MediatorDiscovery
                 $attributes = collect($structure->attributes);
 
                 $hasRequestHandler = $attributes->contains(
-                    fn (DiscoveredAttribute $attr) => $attr->class === MediatorConstants::ATTRIBUTE_REQUEST_HANDLER
+                    fn (DiscoveredAttribute $attr) => in_array($attr->class, MediatorConstants::REQUEST_HANDLER_ATTRIBUTES, true)
                 );
 
                 if ($hasRequestHandler) {
@@ -120,15 +122,18 @@ final class MediatorDiscovery
      */
     private static function discoverHandlers(ReflectionClass $reflection, string $className, array &$discovered): void
     {
-        $attributes = $reflection->getAttributes(MediatorConstants::ATTRIBUTE_REQUEST_HANDLER);
-        if (! empty($attributes)) {
-            /** @var RequestHandler $attr */
-            $attr = $attributes[0]->newInstance();
-            $requestClass = $attr->requestClass;
+        foreach (MediatorConstants::REQUEST_HANDLER_ATTRIBUTES as $attrClass) {
+            $attributes = $reflection->getAttributes($attrClass);
+            if (! empty($attributes)) {
+                /** @var RequestHandler $attr */
+                $attr = $attributes[0]->newInstance();
+                $requestClass = $attr->requestClass;
 
-            if (! empty($requestClass)) {
-                self::ensureTargetClassExists($requestClass, $className);
-                $discovered['handlers'][$requestClass] = $className;
+                if (! empty($requestClass)) {
+                    self::ensureTargetClassExists($requestClass, $className, $attrClass);
+                    $discovered['handlers'][$requestClass] = $className;
+                }
+                break;
             }
         }
     }
@@ -148,7 +153,7 @@ final class MediatorDiscovery
             $eventClass = $attr->eventClass;
 
             if (! empty($eventClass)) {
-                self::ensureTargetClassExists($eventClass, $className);
+                self::ensureTargetClassExists($eventClass, $className, MediatorConstants::ATTRIBUTE_NOTIFICATION);
                 $discovered['notifications'][$eventClass][] = [
                     'handler' => $className,
                     'priority' => $attr->priority,
@@ -182,10 +187,10 @@ final class MediatorDiscovery
     /**
      * @throws InvalidRequestClassException
      */
-    private static function ensureTargetClassExists(string $targetClass, string $handlerClass): void
+    private static function ensureTargetClassExists(string $targetClass, string $handlerClass, string $attributeClass = ''): void
     {
         if (! class_exists($targetClass)) {
-            throw new InvalidRequestClassException($targetClass, $handlerClass);
+            throw new InvalidRequestClassException($targetClass, $handlerClass, $attributeClass);
         }
     }
 

--- a/src/Discovery/MediatorDiscovery.php
+++ b/src/Discovery/MediatorDiscovery.php
@@ -6,8 +6,6 @@ namespace Ignaciocastro0713\CqbusMediator\Discovery;
 
 use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\Notification;
 use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
-use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
-use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
 use Ignaciocastro0713\CqbusMediator\Constants\MediatorConstants;
 use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidRequestClassException;
 use InvalidArgumentException;
@@ -133,6 +131,7 @@ final class MediatorDiscovery
                     self::ensureTargetClassExists($requestClass, $className, $attrClass);
                     $discovered['handlers'][$requestClass] = $className;
                 }
+
                 break;
             }
         }

--- a/src/Exceptions/InvalidPipelineException.php
+++ b/src/Exceptions/InvalidPipelineException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ignaciocastro0713\CqbusMediator\Exceptions;
+
+use Exception;
+
+class InvalidPipelineException extends Exception
+{
+    public function __construct(
+        public readonly string $pipelineClass,
+        public readonly string $context = ''
+    ) {
+        $message = "Pipeline class '$pipelineClass' is invalid or does not exist";
+
+        if ($context !== '') {
+            $message .= " (configured in '$context')";
+        }
+
+        $message .= ".\n\n";
+        $message .= "Suggested solutions:\n";
+        $message .= "1. Verify the class name and namespace are correct.\n";
+        $message .= "2. Ensure the class has a public 'handle(\$payload, Closure \$next): mixed' method.\n";
+        $message .= "3. Run 'composer dump-autoload' to refresh autoloading.\n";
+        $message .= "4. Check 'config/mediator.php' for typos in global_pipelines, request_pipelines, or notification_pipelines.";
+
+        parent::__construct($message);
+    }
+}

--- a/src/Exceptions/InvalidRequestClassException.php
+++ b/src/Exceptions/InvalidRequestClassException.php
@@ -10,9 +10,13 @@ class InvalidRequestClassException extends Exception
 {
     public function __construct(
         public readonly string $requestClass,
-        public readonly string $handlerClass
+        public readonly string $handlerClass,
+        public readonly string $attributeClass = ''
     ) {
-        $message = "Request class '$requestClass' specified in handler '$handlerClass' does not exist.\n\n";
+        $attrName = $attributeClass !== '' ? '#[' . class_basename($attributeClass) . ']' : '';
+        $source = $attrName !== '' ? "referenced in $attrName on '$handlerClass'" : "specified in handler '$handlerClass'";
+
+        $message = "Request class '$requestClass' $source does not exist.\n\n";
         $message .= "Suggested solutions:\n";
         $message .= "1. Verify the namespace and class name are correct\n";
         $message .= "2. Make sure the request class file exists\n";

--- a/src/Facades/Mediator.php
+++ b/src/Facades/Mediator.php
@@ -6,11 +6,12 @@ namespace Ignaciocastro0713\CqbusMediator\Facades;
 
 use Ignaciocastro0713\CqbusMediator\Contracts\Mediator as MediatorContract;
 use Ignaciocastro0713\CqbusMediator\Support\MediatorFake;
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static mixed send(object $request)
- * @method static array<string, mixed> publish(object $event)
+ * @method static PublishResults publish(object $event)
  * @method static void assertSent(string|callable $request)
  * @method static void assertNotSent(string|callable $request)
  * @method static void assertPublished(string|callable $event)

--- a/src/Services/MediatorService.php
+++ b/src/Services/MediatorService.php
@@ -53,7 +53,7 @@ class MediatorService implements Mediator
      * MediatorService constructor.
      *
      * @param Application $app
-     * @throws InvalidRequestClassException
+     * @throws InvalidRequestClassException|InvalidPipelineException
      */
     public function __construct(private readonly Application $app)
     {

--- a/src/Services/MediatorService.php
+++ b/src/Services/MediatorService.php
@@ -11,8 +11,10 @@ use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
 use Ignaciocastro0713\CqbusMediator\Discovery\MediatorDiscovery;
 use Ignaciocastro0713\CqbusMediator\Exceptions\HandlerNotFoundException;
 use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidHandlerException;
+use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidPipelineException;
 use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidRequestClassException;
 use Ignaciocastro0713\CqbusMediator\MediatorConfig;
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Pipeline\Pipeline;
@@ -31,6 +33,14 @@ class MediatorService implements Mediator
     /** @var array<class-string> */
     private array $globalPipelines;
 
+    /** @var array<class-string> */
+    private array $requestPipelines;
+
+    /** @var array<class-string> */
+    private array $notificationPipelines;
+
+    private bool $loadedFromCache = false;
+
     /**
      * Cache for resolved pipelines per handler class.
      * Avoids repeated Reflection calls for the same handler.
@@ -48,7 +58,13 @@ class MediatorService implements Mediator
     public function __construct(private readonly Application $app)
     {
         $this->loadRegistry();
-        $this->globalPipelines = MediatorConfig::pipelines();
+        $this->globalPipelines       = MediatorConfig::pipelines();
+        $this->requestPipelines      = MediatorConfig::requestPipelines();
+        $this->notificationPipelines = MediatorConfig::notificationPipelines();
+
+        if (! $this->loadedFromCache) {
+            $this->validatePipelines();
+        }
     }
 
     /**
@@ -83,17 +99,17 @@ class MediatorService implements Mediator
      * Handlers are executed in priority order (higher priority first).
      *
      * @param object $event The event object to publish
-     * @return array<string, mixed> Results from all handlers, keyed by handler class name
+     * @return PublishResults Results from all handlers, keyed by handler class name
      * @throws BindingResolutionException
      * @throws InvalidHandlerException
      */
-    public function publish(object $event): array
+    public function publish(object $event): PublishResults
     {
         $eventClass = $event::class;
         $handlers = $this->notifications[$eventClass] ?? [];
 
         if (empty($handlers)) {
-            return [];
+            return new PublishResults();
         }
 
         $results = [];
@@ -108,7 +124,7 @@ class MediatorService implements Mediator
             $results[$handlerClass] = $this->executeThroughPipelines($event, $handler, $pipelines);
         }
 
-        return $results;
+        return new PublishResults($results);
     }
 
     /**
@@ -171,8 +187,8 @@ class MediatorService implements Mediator
         }
 
         $typePipelines = $type === MediatorConstants::PIPELINE_TYPE_REQUEST
-            ? MediatorConfig::requestPipelines()
-            : MediatorConfig::notificationPipelines();
+            ? $this->requestPipelines
+            : $this->notificationPipelines;
 
         try {
             $reflection = new ReflectionClass($handlerClass);
@@ -195,6 +211,29 @@ class MediatorService implements Mediator
     }
 
     /**
+     * Validates that all configured pipeline classes exist.
+     * Only called during dynamic discovery (not when loading from cache).
+     *
+     * @throws InvalidPipelineException
+     */
+    private function validatePipelines(): void
+    {
+        $checks = [
+            'global_pipelines'       => $this->globalPipelines,
+            'request_pipelines'      => $this->requestPipelines,
+            'notification_pipelines' => $this->notificationPipelines,
+        ];
+
+        foreach ($checks as $context => $pipelines) {
+            foreach ($pipelines as $pipelineClass) {
+                if (! class_exists($pipelineClass)) {
+                    throw new InvalidPipelineException($pipelineClass, $context);
+                }
+            }
+        }
+    }
+
+    /**
      * Loads the mediator registry (handlers, notifications, and pipelines) from the
      * unified cache file if available, otherwise scans directories for discovery.
      *
@@ -210,6 +249,7 @@ class MediatorService implements Mediator
             $this->handlers = $cached['handlers'] ?? [];
             $this->notifications = $cached['notifications'] ?? [];
             $this->pipelinesCache = $cached['pipelines'] ?? [];
+            $this->loadedFromCache = true;
 
             return;
         }

--- a/src/Services/MediatorService.php
+++ b/src/Services/MediatorService.php
@@ -58,8 +58,8 @@ class MediatorService implements Mediator
     public function __construct(private readonly Application $app)
     {
         $this->loadRegistry();
-        $this->globalPipelines       = MediatorConfig::pipelines();
-        $this->requestPipelines      = MediatorConfig::requestPipelines();
+        $this->globalPipelines = MediatorConfig::pipelines();
+        $this->requestPipelines = MediatorConfig::requestPipelines();
         $this->notificationPipelines = MediatorConfig::notificationPipelines();
 
         if (! $this->loadedFromCache) {
@@ -219,8 +219,8 @@ class MediatorService implements Mediator
     private function validatePipelines(): void
     {
         $checks = [
-            'global_pipelines'       => $this->globalPipelines,
-            'request_pipelines'      => $this->requestPipelines,
+            'global_pipelines' => $this->globalPipelines,
+            'request_pipelines' => $this->requestPipelines,
             'notification_pipelines' => $this->notificationPipelines,
         ];
 

--- a/src/Support/MediatorFake.php
+++ b/src/Support/MediatorFake.php
@@ -6,7 +6,6 @@ namespace Ignaciocastro0713\CqbusMediator\Support;
 
 use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
 use Illuminate\Support\Collection;
-use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MediatorFake implements Mediator

--- a/src/Support/MediatorFake.php
+++ b/src/Support/MediatorFake.php
@@ -6,6 +6,7 @@ namespace Ignaciocastro0713\CqbusMediator\Support;
 
 use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
 use Illuminate\Support\Collection;
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MediatorFake implements Mediator
@@ -29,11 +30,11 @@ class MediatorFake implements Mediator
     /**
      * Fake the publish method by just recording the event.
      */
-    public function publish(object $event): array
+    public function publish(object $event): PublishResults
     {
         $this->published[] = $event;
 
-        return [];
+        return new PublishResults();
     }
 
     /**

--- a/src/Support/PublishResults.php
+++ b/src/Support/PublishResults.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ignaciocastro0713\CqbusMediator\Support;
+
+use ArrayAccess;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Typed result bag returned by Mediator::publish().
+ *
+ * Implements ArrayAccess, Countable, and IteratorAggregate so that existing
+ * code using foreach, count(), and array-key access continues to work unchanged.
+ *
+ * @implements ArrayAccess<string, mixed>
+ * @implements IteratorAggregate<string, mixed>
+ */
+final class PublishResults implements ArrayAccess, Countable, IteratorAggregate
+{
+    /** @param array<string, mixed> $results */
+    public function __construct(private array $results = []) {}
+
+    /** @return array<string, mixed> */
+    public function all(): array
+    {
+        return $this->results;
+    }
+
+    public function get(string $handlerClass): mixed
+    {
+        return $this->results[$handlerClass] ?? null;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->results);
+    }
+
+    public function count(): int
+    {
+        return count($this->results);
+    }
+
+    /** @return array<int, string> */
+    public function handlerClasses(): array
+    {
+        return array_keys($this->results);
+    }
+
+    /** @return ArrayIterator<string, mixed> */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->results);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->results[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->results[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->results[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->results[$offset]);
+    }
+}

--- a/src/Support/PublishResults.php
+++ b/src/Support/PublishResults.php
@@ -21,7 +21,9 @@ use IteratorAggregate;
 final class PublishResults implements ArrayAccess, Countable, IteratorAggregate
 {
     /** @param array<string, mixed> $results */
-    public function __construct(private array $results = []) {}
+    public function __construct(private array $results = [])
+    {
+    }
 
     /** @return array<string, mixed> */
     public function all(): array

--- a/tests/Feature/ActionDecoratorManagerFullCoverageTest.php
+++ b/tests/Feature/ActionDecoratorManagerFullCoverageTest.php
@@ -73,3 +73,19 @@ it('extracts controller class when uses is a closure but controller is a string'
 
     expect($result)->toBe('App\Http\Controllers\FallbackController');
 });
+
+it('getControllerClass returns null when both uses and controller are non-strings', function () {
+    $manager = app(ActionDecoratorManager::class);
+    $reflection = new ReflectionClass($manager);
+    $method = $reflection->getMethod('getControllerClass');
+    $method->setAccessible(true);
+
+    // Closure route: uses is a Closure (not string) and controller is null (not string)
+    $route = new \Illuminate\Routing\Route('GET', '/test-null', function () {
+        return 'test';
+    });
+
+    $result = $method->invoke($manager, $route);
+
+    expect($result)->toBeNull();
+});

--- a/tests/Feature/ActionDecoratorManagerTest.php
+++ b/tests/Feature/ActionDecoratorManagerTest.php
@@ -67,6 +67,50 @@ it('registers routes if routes are NOT cached', function () {
     expect(true)->toBeTrue();
 });
 
+it('falls back to discovery when cache has legacy flat-array actions format', function () {
+    $cachePath = $this->app->bootstrapPath('cache/mediator.php');
+
+    $legacyCache = [
+        'handlers' => [],
+        'notifications' => [],
+        'actions' => [
+            0 => Tests\Fixtures\ApiRouteAction::class,
+            1 => Tests\Fixtures\WebRouteAction::class,
+        ],
+    ];
+
+    file_put_contents($cachePath, '<?php return ' . var_export($legacyCache, true) . ';');
+
+    $manager = app(ActionDecoratorManager::class);
+    $manager->boot();
+
+    expect(true)->toBeTrue();
+
+    Illuminate\Support\Facades\File::delete($cachePath);
+});
+
+it('sorts actions from different non-empty priority groups alphabetically', function () {
+    $cachePath = $this->app->bootstrapPath('cache/mediator.php');
+
+    $cache = [
+        'handlers' => [],
+        'notifications' => [],
+        'actions' => [
+            Tests\Fixtures\PriorityArrayAction::class => ['priority' => 500, 'group' => 'context'],
+            Tests\Fixtures\PriorityHighAction::class => ['priority' => 10, 'group' => 'admin'],
+        ],
+    ];
+
+    file_put_contents($cachePath, '<?php return ' . var_export($cache, true) . ';');
+
+    $manager = app(ActionDecoratorManager::class);
+    $manager->boot();
+
+    expect(true)->toBeTrue();
+
+    Illuminate\Support\Facades\File::delete($cachePath);
+});
+
 it('loads actions from cache when cache file exists', function () {
     // Create cache file with test actions
     $cachePath = $this->app->bootstrapPath('cache/mediator.php');

--- a/tests/Feature/CommandQueryHandlerTest.php
+++ b/tests/Feature/CommandQueryHandlerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
+use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+use Tests\Fixtures\Handlers\CreateUserCommand;
+use Tests\Fixtures\Handlers\CreateUserCommandHandler;
+use Tests\Fixtures\Handlers\GetUserQuery;
+use Tests\Fixtures\Handlers\GetUserQueryHandler;
+
+it('dispatches a command via #[CommandHandler]', function () {
+    $mediator = app(Mediator::class);
+    $result = $mediator->send(new CreateUserCommand('Alice'));
+
+    expect($result)->toBe('user_created:Alice');
+});
+
+it('dispatches a query via #[QueryHandler]', function () {
+    $mediator = app(Mediator::class);
+    $result = $mediator->send(new GetUserQuery('42'));
+
+    expect($result)->toBe('user_found:42');
+});
+
+it('CommandHandler is a subclass of RequestHandler', function () {
+    expect(CommandHandler::class)->toExtend(RequestHandler::class);
+});
+
+it('QueryHandler is a subclass of RequestHandler', function () {
+    expect(QueryHandler::class)->toExtend(RequestHandler::class);
+});
+
+it('CommandHandler handler is registered in discovery', function () {
+    $paths = config('mediator.handler_paths', [app_path()]);
+    $paths = is_array($paths) ? $paths : [$paths];
+    $discovered = \Ignaciocastro0713\CqbusMediator\Discovery\MediatorDiscovery::discover($paths);
+
+    expect($discovered['handlers'])->toHaveKey(CreateUserCommand::class)
+        ->and($discovered['handlers'][CreateUserCommand::class])->toBe(CreateUserCommandHandler::class);
+});
+
+it('QueryHandler handler is registered in discovery', function () {
+    $paths = config('mediator.handler_paths', [app_path()]);
+    $paths = is_array($paths) ? $paths : [$paths];
+    $discovered = \Ignaciocastro0713\CqbusMediator\Discovery\MediatorDiscovery::discover($paths);
+
+    expect($discovered['handlers'])->toHaveKey(GetUserQuery::class)
+        ->and($discovered['handlers'][GetUserQuery::class])->toBe(GetUserQueryHandler::class);
+});

--- a/tests/Feature/InvalidPipelineTest.php
+++ b/tests/Feature/InvalidPipelineTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+use Ignaciocastro0713\CqbusMediator\Exceptions\InvalidPipelineException;
+
+it('throws InvalidPipelineException for non-existent global pipeline', function () {
+    config()->set('mediator.global_pipelines', ['App\\NonExistent\\Pipeline']);
+    $this->app->forgetInstance(Mediator::class);
+
+    expect(fn () => $this->app->make(Mediator::class))
+        ->toThrow(InvalidPipelineException::class, "global_pipelines");
+});
+
+it('throws InvalidPipelineException for non-existent request pipeline', function () {
+    config()->set('mediator.request_pipelines', ['App\\NonExistent\\RequestPipeline']);
+    $this->app->forgetInstance(Mediator::class);
+
+    expect(fn () => $this->app->make(Mediator::class))
+        ->toThrow(InvalidPipelineException::class, "request_pipelines");
+});
+
+it('throws InvalidPipelineException for non-existent notification pipeline', function () {
+    config()->set('mediator.notification_pipelines', ['App\\NonExistent\\NotificationPipeline']);
+    $this->app->forgetInstance(Mediator::class);
+
+    expect(fn () => $this->app->make(Mediator::class))
+        ->toThrow(InvalidPipelineException::class, "notification_pipelines");
+});
+
+it('does not validate pipelines when loading from cache', function () {
+    // Build a cache file with an invalid pipeline to simulate upgrading with stale config
+    $cachePath = $this->app->bootstrapPath('cache/mediator.php');
+    file_put_contents($cachePath, "<?php\nreturn ['handlers'=>[],'notifications'=>[],'actions'=>[],'pipelines'=>[]];\n");
+
+    config()->set('mediator.global_pipelines', ['App\\NonExistent\\Pipeline']);
+    $this->app->forgetInstance(Mediator::class);
+
+    // Should NOT throw — validation is skipped when cache file exists
+    expect(fn () => $this->app->make(Mediator::class))->not->toThrow(InvalidPipelineException::class);
+
+    // Cleanup
+    @unlink($cachePath);
+});

--- a/tests/Feature/MediatorListCommandTest.php
+++ b/tests/Feature/MediatorListCommandTest.php
@@ -145,3 +145,29 @@ it('shows message when no actions are registered', function () {
     // Cleanup
     rmdir($emptyDir);
 });
+
+it('shows Pipelines column in handlers table', function () {
+    Artisan::call('mediator:list', ['--handlers' => true]);
+
+    expect(Artisan::output())->toContain('Pipelines');
+});
+
+it('shows Pipelines column in event handlers table', function () {
+    Artisan::call('mediator:list', ['--events' => true]);
+
+    expect(Artisan::output())->toContain('Pipelines');
+});
+
+it('warns when cache is active in non-production environment', function () {
+    Artisan::call('mediator:cache');
+    Artisan::call('mediator:list');
+
+    // The test environment is 'testing', not 'production'
+    expect(Artisan::output())->toContain('non-production environment');
+});
+
+it('shows (none) when no pipelines are configured for a handler', function () {
+    Artisan::call('mediator:list', ['--handlers' => true]);
+
+    expect(Artisan::output())->toContain('(none)');
+});

--- a/tests/Feature/MediatorListCommandTest.php
+++ b/tests/Feature/MediatorListCommandTest.php
@@ -171,3 +171,17 @@ it('shows (none) when no pipelines are configured for a handler', function () {
 
     expect(Artisan::output())->toContain('(none)');
 });
+
+it('handles reflection exception gracefully for non-existent handler class in cache', function () {
+    $fakeCache = [
+        'handlers' => ['Tests\Fixtures\Handlers\BasicRequest' => 'NonExistentHandlerClass'],
+        'actions' => [],
+        'notifications' => [],
+    ];
+
+    file_put_contents($this->cachePath, '<?php return ' . var_export($fakeCache, true) . ';');
+
+    Artisan::call('mediator:list', ['--handlers' => true]);
+
+    expect(Artisan::output())->toContain('Handlers');
+});

--- a/tests/Fixtures/Handlers/CreateUserCommand.php
+++ b/tests/Fixtures/Handlers/CreateUserCommand.php
@@ -6,5 +6,7 @@ namespace Tests\Fixtures\Handlers;
 
 class CreateUserCommand
 {
-    public function __construct(public readonly string $name = 'John') {}
+    public function __construct(public readonly string $name = 'John')
+    {
+    }
 }

--- a/tests/Fixtures/Handlers/CreateUserCommand.php
+++ b/tests/Fixtures/Handlers/CreateUserCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Handlers;
+
+class CreateUserCommand
+{
+    public function __construct(public readonly string $name = 'John') {}
+}

--- a/tests/Fixtures/Handlers/CreateUserCommandHandler.php
+++ b/tests/Fixtures/Handlers/CreateUserCommandHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Handlers;
+
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\CommandHandler;
+
+#[CommandHandler(CreateUserCommand::class)]
+class CreateUserCommandHandler
+{
+    public function handle(CreateUserCommand $command): string
+    {
+        return 'user_created:' . $command->name;
+    }
+}

--- a/tests/Fixtures/Handlers/GetUserQuery.php
+++ b/tests/Fixtures/Handlers/GetUserQuery.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Handlers;
+
+class GetUserQuery
+{
+    public function __construct(public readonly string $id = '1') {}
+}

--- a/tests/Fixtures/Handlers/GetUserQuery.php
+++ b/tests/Fixtures/Handlers/GetUserQuery.php
@@ -6,5 +6,7 @@ namespace Tests\Fixtures\Handlers;
 
 class GetUserQuery
 {
-    public function __construct(public readonly string $id = '1') {}
+    public function __construct(public readonly string $id = '1')
+    {
+    }
 }

--- a/tests/Fixtures/Handlers/GetUserQueryHandler.php
+++ b/tests/Fixtures/Handlers/GetUserQueryHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Handlers;
+
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\QueryHandler;
+
+#[QueryHandler(GetUserQuery::class)]
+class GetUserQueryHandler
+{
+    public function handle(GetUserQuery $query): string
+    {
+        return 'user_found:' . $query->id;
+    }
+}

--- a/tests/Fixtures/PrivateConstructorHandler.php
+++ b/tests/Fixtures/PrivateConstructorHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Ignaciocastro0713\CqbusMediator\Attributes\Handlers\RequestHandler;
+use Tests\Fixtures\Handlers\BasicRequest;
+
+#[RequestHandler(BasicRequest::class)]
+class PrivateConstructorHandler
+{
+    private function __construct() {}
+
+    public function handle(BasicRequest $request): void {}
+}

--- a/tests/Unit/Discovery/MediatorDiscoveryTest.php
+++ b/tests/Unit/Discovery/MediatorDiscoveryTest.php
@@ -50,4 +50,26 @@ class MediatorDiscoveryTest extends TestCase
         $directories = [__DIR__ . '/../../InvalidFixtures/InvalidEventHandlers/NonExistentEvent'];
         MediatorDiscovery::discover($directories);
     }
+
+    public function test_it_skips_classes_that_are_not_autoloaded(): void
+    {
+        $directories = [__DIR__ . '/../../NonAutoloadedFixtures/ReflectionFailure'];
+
+        $discovered = MediatorDiscovery::discover($directories);
+
+        $this->assertEmpty($discovered['handlers']);
+        $this->assertEmpty($discovered['notifications']);
+    }
+
+    public function test_it_skips_non_instantiable_classes(): void
+    {
+        $directories = [__DIR__ . '/../../Fixtures'];
+
+        $discovered = MediatorDiscovery::discover($directories);
+
+        $this->assertArrayNotHasKey(
+            \Tests\Fixtures\PrivateConstructorHandler::class,
+            $discovered['handlers']
+        );
+    }
 }

--- a/tests/Unit/EventBusTest.php
+++ b/tests/Unit/EventBusTest.php
@@ -2,6 +2,7 @@
 
 use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
 use Ignaciocastro0713\CqbusMediator\Discovery\MediatorDiscovery;
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Tests\Fixtures\EventHandlers\CreateDefaultSettingsHandler;
@@ -26,7 +27,7 @@ it('publishes an event to multiple handlers', function () {
 
     $results = $this->mediator->publish($event);
 
-    expect($results)->toBeArray()
+    expect($results)->toBeInstanceOf(PublishResults::class)
         ->and($results)->toHaveCount(3);
 });
 
@@ -36,7 +37,7 @@ it('executes notifications in priority order (higher first)', function () {
     $results = $this->mediator->publish($event);
 
     // Convert to array to check order
-    $handlerOrder = array_keys($results);
+    $handlerOrder = $results->handlerClasses();
 
     // Priority order: SendWelcomeEmailHandler (10), CreateDefaultSettingsHandler (5), LogUserRegistrationHandler (1)
     expect($handlerOrder[0])->toBe(SendWelcomeEmailHandler::class)
@@ -49,21 +50,21 @@ it('returns results keyed by handler class name', function () {
 
     $results = $this->mediator->publish($event);
 
-    expect($results)->toHaveKey(SendWelcomeEmailHandler::class)
-        ->and($results)->toHaveKey(CreateDefaultSettingsHandler::class)
-        ->and($results)->toHaveKey(LogUserRegistrationHandler::class)
-        ->and($results[SendWelcomeEmailHandler::class])->toBe('welcome_email_sent_to_test@example.com')
-        ->and($results[CreateDefaultSettingsHandler::class])->toBe('settings_created_for_user-123')
-        ->and($results[LogUserRegistrationHandler::class])->toBe('logged_registration_user-123');
+    expect($results->get(SendWelcomeEmailHandler::class))->toBe('welcome_email_sent_to_test@example.com')
+        ->and($results->get(CreateDefaultSettingsHandler::class))->toBe('settings_created_for_user-123')
+        ->and($results->get(LogUserRegistrationHandler::class))->toBe('logged_registration_user-123')
+        ->and($results->handlerClasses())->toContain(SendWelcomeEmailHandler::class)
+        ->and($results->handlerClasses())->toContain(CreateDefaultSettingsHandler::class)
+        ->and($results->handlerClasses())->toContain(LogUserRegistrationHandler::class);
 });
 
-it('returns empty array when no handlers registered for event', function () {
+it('returns empty results when no handlers registered for event', function () {
     $event = new EventWithoutHandlers();
 
     $results = $this->mediator->publish($event);
 
-    expect($results)->toBeArray()
-        ->and($results)->toBeEmpty();
+    expect($results)->toBeInstanceOf(PublishResults::class)
+        ->and($results->isEmpty())->toBeTrue();
 });
 
 it('discovers notifications correctly', function () {
@@ -119,8 +120,8 @@ it('executes event handler with pipeline', function () {
     $results = $mediator->publish($event);
 
     // The BasicPipeline modifies the result by setting a 'processed' property
-    expect($results)->toBeArray()
-        ->and($results)->not->toBeEmpty();
+    expect($results)->toBeInstanceOf(PublishResults::class)
+        ->and($results->isEmpty())->toBeFalse();
 });
 
 it('event handler discovery returns handlers sorted by priority', function () {

--- a/tests/Unit/PipelineCacheTest.php
+++ b/tests/Unit/PipelineCacheTest.php
@@ -2,7 +2,6 @@
 
 use Ignaciocastro0713\CqbusMediator\Constants\MediatorConstants;
 use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
-use Ignaciocastro0713\CqbusMediator\Services\MediatorService;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Tests\Fixtures\Handlers\BasicRequest;

--- a/tests/Unit/PipelineCacheTest.php
+++ b/tests/Unit/PipelineCacheTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Ignaciocastro0713\CqbusMediator\Constants\MediatorConstants;
+use Ignaciocastro0713\CqbusMediator\Contracts\Mediator;
+use Ignaciocastro0713\CqbusMediator\Services\MediatorService;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\Fixtures\Handlers\BasicRequest;
+
+beforeEach(function () {
+    $this->cachePath = $this->app->bootstrapPath('cache/mediator.php');
+});
+
+afterEach(function () {
+    if (File::exists($this->cachePath)) {
+        File::delete($this->cachePath);
+    }
+});
+
+it('pipeline cache keys include type suffix after mediator:cache', function () {
+    Artisan::call('mediator:cache');
+
+    $cached = require $this->cachePath;
+    $pipelines = $cached['pipelines'];
+
+    foreach (array_keys($pipelines) as $key) {
+        expect($key)->toMatch('/:(request|notification)$/');
+    }
+});
+
+it('resolves pipelines from cache without ReflectionClass on dispatch', function () {
+    Artisan::call('mediator:cache');
+
+    $this->app->forgetInstance(Mediator::class);
+    $mediator = $this->app->make(Mediator::class);
+
+    // Pipeline cache should be pre-warmed — dispatch should work correctly
+    $result = $mediator->send(new BasicRequest('test'));
+
+    expect($result)->not->toBeNull();
+});
+
+it('request handlers use request pipeline type in cache key', function () {
+    Artisan::call('mediator:cache');
+
+    $cached = require $this->cachePath;
+    $pipelines = $cached['pipelines'];
+
+    $requestKeys = array_filter(array_keys($pipelines), fn (string $k) => str_ends_with($k, ':' . MediatorConstants::PIPELINE_TYPE_REQUEST));
+
+    expect($requestKeys)->not->toBeEmpty();
+});

--- a/tests/Unit/PublishResultsTest.php
+++ b/tests/Unit/PublishResultsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Ignaciocastro0713\CqbusMediator\Support\PublishResults;
+
+it('wraps results and exposes typed API', function () {
+    $results = new PublishResults(['HandlerA' => 'val1', 'HandlerB' => null]);
+
+    expect($results->all())->toBe(['HandlerA' => 'val1', 'HandlerB' => null])
+        ->and($results->get('HandlerA'))->toBe('val1')
+        ->and($results->get('NonExistent'))->toBeNull()
+        ->and($results->isEmpty())->toBeFalse()
+        ->and($results->count())->toBe(2)
+        ->and($results->handlerClasses())->toBe(['HandlerA', 'HandlerB']);
+});
+
+it('is iterable via foreach', function () {
+    $results = new PublishResults(['A' => 1, 'B' => 2]);
+
+    $collected = [];
+    foreach ($results as $key => $val) {
+        $collected[$key] = $val;
+    }
+
+    expect($collected)->toBe(['A' => 1, 'B' => 2]);
+});
+
+it('supports array-style access', function () {
+    $results = new PublishResults(['A' => 'foo']);
+
+    expect($results['A'])->toBe('foo')
+        ->and(isset($results['A']))->toBeTrue()
+        ->and(isset($results['B']))->toBeFalse();
+});
+
+it('supports array-style mutation', function () {
+    $results = new PublishResults(['A' => 'foo']);
+    $results['B'] = 'bar';
+    unset($results['A']);
+
+    expect(isset($results['A']))->toBeFalse()
+        ->and($results['B'])->toBe('bar');
+});
+
+it('is empty when constructed with no results', function () {
+    $results = new PublishResults();
+
+    expect($results->isEmpty())->toBeTrue()
+        ->and($results->count())->toBe(0)
+        ->and($results->handlerClasses())->toBe([]);
+});


### PR DESCRIPTION
- Add PublishResults typed return value for publish() (implements ArrayAccess,
  Countable, IteratorAggregate for full backward compatibility)
- Add #[CommandHandler] and #[QueryHandler] semantic CQRS attribute aliases
- Fix CacheCommand pipeline cache key bug: keys now include ':request'/':notification'
  suffix so MediatorService cache lookups actually hit in production
- Cache requestPipelines/notificationPipelines as MediatorService properties
  (avoids repeated config() calls per dispatch)
- Skip validatePipelines() when loading from cache (no overhead in production)
- Add InvalidPipelineException thrown at boot when a pipeline class does not exist
- Improve InvalidRequestClassException to include which attribute references the
  non-existent class (#[RequestHandler], #[CommandHandler], #[Notification], etc.)
- Extend mediator:list with Pipelines column showing effective pipeline stack
- Add non-production environment warning when discovery cache is active
- Add docs/7.0/ with upgrade guide, DDD examples, pipeline execution diagram,
  Commands vs Queries vs Events table, and PublishResults API docs
- Update README with same additions

https://claude.ai/code/session_01AeyyUZ1nNU2tpv4MdNM9Kw